### PR TITLE
Improve responsive layout for all screen sizes

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -52,6 +52,16 @@ ul {
   cursor: pointer;
 }
 
+/* Constrain main sections to a centered layout */
+.navbar,
+.hero,
+.feature-split,
+.contact,
+.footer {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
 /* Hero */
 .hero {
   display: flex;
@@ -77,7 +87,7 @@ ul {
 
 .hero-images {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 15px;
   flex: 1 1 45%;
 }
@@ -483,22 +493,22 @@ ul {
     display: block;
   }
 
-  .navbar nav {
+  .main-nav {
     width: 100%;
     display: none;
   }
 
-  .navbar nav.open {
+  .navbar.is-open .main-nav {
     display: block;
   }
 
-  .navbar nav ul {
+  .main-nav ul {
     flex-direction: column;
     gap: 10px;
     padding: 10px 0;
   }
 
-  .navbar .btn-primary {
+  .btn-primary {
     display: none;
   }
 

--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
 <body>
   <header class="navbar">
     <div class="logo">⭐ iAgency</div>
-    <button class="menu-toggle" aria-label="Toggle navigation">☰</button>
-    <nav class="main-nav" aria-label="Primary">
+    <button class="menu-toggle" aria-label="Toggle navigation" aria-controls="primary-menu" aria-expanded="false">☰</button>
+    <nav id="primary-menu" class="main-nav" aria-label="Primary">
       <ul>
         <!-- Dropdown Work -->
         <li class="dropdown">


### PR DESCRIPTION
## Summary
- center main sections and refine hero image grid for flexible layouts
- add accessible mobile nav toggle and responsive menu display

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cf2359f2083229ee3cd595e17f5ec