### PR TITLE
feat: add scroll reveal overlap for stack cards

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -725,3 +725,74 @@ nav ul li a:hover {
 /* Focus outline for accessibility */
 :focus-visible { outline: 2px solid rgba(59,130,246,.8); outline-offset: 3px; }
 
+/* === Scroll Reveal + Overlap (injected by Codex) === */
+.stack-overlap {
+  --overlap: clamp(10px, 2.2vw, 28px);
+  position: relative;
+}
+.stack-overlap .stack-card {
+  position: relative;
+  margin-top: calc(var(--overlap) * -1);
+  padding-top: calc(var(--overlap) + 8px);
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.08);
+  background: #fff;
+  backdrop-filter: saturate(1.05);
+}
+.stack-overlap .stack-card:first-child {
+  margin-top: 0;
+  padding-top: 16px;
+}
+
+/* Reveal base */
+.stack-overlap .stack-card[data-reveal] {
+  opacity: 0;
+  transform: translateY(20px);
+  transition:
+    opacity 520ms ease,
+    transform 520ms cubic-bezier(.22,.61,.36,1);
+  will-change: opacity, transform;
+}
+.stack-overlap .stack-card[data-reveal].is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Realce sutil al estar visible (refuerza el “montado”) */
+.stack-overlap .stack-card.is-visible {
+  box-shadow: 0 16px 40px rgba(0,0,0,0.10);
+}
+
+/* Hover opcional */
+@media (hover:hover) {
+  .stack-overlap .stack-card.is-visible:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 20px 50px rgba(0,0,0,0.12);
+  }
+}
+
+/* Accesibilidad */
+@media (prefers-reduced-motion: reduce) {
+  .stack-overlap .stack-card[data-reveal] {
+    transition: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}
+
+/* Enhancement: scroll-driven animation (si hay soporte) */
+@supports (animation-timeline: view()) {
+  .stack-overlap .stack-card[data-reveal] {
+    opacity: 0;
+    transform: translateY(24px);
+    animation: reveal-fade-up 1 both;
+    animation-timeline: view();
+    animation-range: entry 10% cover 60%;
+  }
+  @keyframes reveal-fade-up {
+    from { opacity: 0; transform: translateY(24px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+}
+/* === End Scroll Reveal + Overlap === */
+

--- a/index.html
+++ b/index.html
@@ -140,26 +140,26 @@
 
     <!-- Textos apilables -->
     <div class="split-text">
-      <div class="stack-container">
-        <div class="stack-card">
+      <div class="stack-container stack-overlap">
+        <div class="stack-card" data-reveal="fade-up" data-reveal-delay="0ms">
           <p class="label">MULTICHANNEL REACH</p>
           <h2>Support customers on every channel</h2>
           <p>Be everywhere your customers are. From WhatsApp to Instagram, offer fast, consistent AI-powered support — 24/7.</p>
         </div>
 
-        <div class="stack-card">
+        <div class="stack-card" data-reveal="fade-up" data-reveal-delay="100ms">
           <p class="label">AI-POWERED AUTOMATION</p>
           <h2>Automate work. Accelerate growth.</h2>
           <p>Let AI handle the busywork. Empower your team to focus on innovation and real results.</p>
         </div>
 
-        <div class="stack-card">
+        <div class="stack-card" data-reveal="fade-up" data-reveal-delay="200ms">
           <p class="label">SMART WORKFLOWS</p>
           <h2>Integrate seamlessly</h2>
           <p>Connect your tools and services to build custom workflows that save time and reduce errors.</p>
         </div>
 
-        <div class="stack-card">
+        <div class="stack-card" data-reveal="fade-up" data-reveal-delay="300ms">
           <p class="label">24/7 SUPPORT</p>
           <h2>Always-on assistance</h2>
           <p>Your AI assistant never sleeps. Deliver reliable support across all your channels, any time of day.</p>
@@ -306,6 +306,40 @@
       }
     });
   </script>
+  <!-- Scroll Reveal + Overlap (injected by Codex) -->
+  <script>
+  (function () {
+    const cards = Array.from(document.querySelectorAll('.stack-overlap .stack-card[data-reveal]'));
+    if (!cards.length) return;
+
+    // z-index ascendente: la card que entra queda por encima (efecto solapado)
+    cards.forEach((el, i) => { el.style.zIndex = String(100 + i); });
+
+    if (!('IntersectionObserver' in window)) {
+      cards.forEach(el => el.classList.add('is-visible'));
+      return;
+    }
+
+    const io = new IntersectionObserver((entries, observer) => {
+      entries.forEach(entry => {
+        const el = entry.target;
+        if (entry.isIntersecting) {
+          const delay = el.getAttribute('data-reveal-delay');
+          if (delay) el.style.transitionDelay = delay;
+          el.classList.add('is-visible');
+          observer.unobserve(el); // animar solo una vez
+        }
+      });
+    }, {
+      root: null,
+      threshold: 0.1,
+      rootMargin: '0px 0px -8% 0px'
+    });
+
+    cards.forEach(el => io.observe(el));
+  })();
+  </script>
+  <!-- End Scroll Reveal + Overlap -->
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- overlap stack card list and fade-up as cards enter viewport
- add scroll reveal observer with z-index stacking

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a47c9d3eec8322ab91c26f4462aefa