### PR TITLE
Fix responsive dropdown

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -18,6 +18,12 @@ ul {
   margin: 0;
 }
 
+/* Responsive dropdown fix */
+.site-header, header, .main-nav {
+  position: relative;
+  z-index: 1000;
+}
+
 .navbar {
   display: flex;
   justify-content: space-between;
@@ -558,28 +564,82 @@ nav ul li a:hover {
   position: relative;
 }
 
+/* Responsive dropdown fix */
 .dropdown-menu {
   position: absolute;
-  top: 100%;
-  left: 0;
-  background: white;
-  border-radius: 16px;
-  padding: 30px; /* más espacio interno */
-  display: none;
-  box-shadow: 0 4px 30px rgba(0,0,0,0.1);
-  min-width: 900px; /* ancho mínimo mayor */
-  max-width: 1100px; /* opcional */
-  z-index: 10;
-}
-
-.dropdown:hover .dropdown-menu {
+  top: calc(100% + 12px);
+  left: 50%;
+  transform: translate(-50%, 8px);
+  width: clamp(720px, 88vw, 1200px);
+  max-width: calc(100vw - 24px);
+  margin-inline: 12px;
+  background: #fff;
+  border-radius: 14px;
+  padding: 32px;
+  box-shadow: 0 12px 40px rgba(0,0,0,.12);
   display: block;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity .2s ease, transform .2s ease;
+  z-index: 2000; /* por encima del hero */
 }
 
-.dropdown-content {
-  display: flex;
-  justify-content: space-between;
-  gap: 40px; /* más separación entre columnas */
+/* Responsive dropdown fix */
+.dropdown.open > .dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translate(-50%, 0);
+}
+
+/* Responsive dropdown fix */
+.dropdown.open > .dropdown-toggle .arrow {
+  transform: rotate(180deg);
+}
+
+/* Responsive dropdown fix */
+.hero, .hero-grid, .gallery-grid, .grid, .masonry {
+  position: relative;
+  z-index: 1;
+  overflow: visible; /* importante para que no recorte */
+}
+
+/* Responsive dropdown fix */
+@media (max-width: 1024px) {
+  .dropdown-menu {
+    width: min(92vw, 820px);
+    padding: 24px;
+  }
+}
+
+/* Responsive dropdown fix */
+@media (max-width: 768px) {
+  .dropdown-menu {
+    position: fixed;
+    left: 0;
+    right: 0;
+    top: var(--nav-bottom, 64px);
+    transform: none;
+    width: 100vw;
+    max-width: 100vw;
+    height: auto;
+    max-height: calc(100vh - var(--nav-bottom, 64px) - 16px);
+    margin: 0;
+    border-radius: 12px;
+    padding: 20px;
+    overflow: auto;
+    box-shadow: 0 12px 40px rgba(0,0,0,.18);
+  }
+
+  body.menu-open {
+    overflow: hidden;
+  }
+}
+
+/* Responsive dropdown fix */
+.nav-link.dropdown-toggle {
+  -webkit-tap-highlight-color: transparent;
 }
 
 /* --- NAV base & hover pills --- */
@@ -605,27 +665,6 @@ nav ul li a:hover {
 .nav-link:hover { background: #f3f3f3; }
 
 .arrow { font-size: .75em; transition: transform .2s ease; }
-
-/* --- Mega dropdown (desktop) --- */
-.dropdown-menu {
-  position: absolute;
-  top: calc(100% + 12px);
-  left: 0;
-  background: #fff;
-  border-radius: 16px;
-  padding: 28px;
-  display: none;
-  box-shadow: 0 12px 40px rgba(0,0,0,.12);
-  min-width: 920px;   /* tamaño grande como referencia */
-  max-width: 1120px;  /* opcional */
-  z-index: 50;
-}
-
-/* Abrir por hover en desktop y por clase .open en JS */
-.dropdown:hover > .dropdown-menu { display: block; }
-.dropdown.no-hover:hover > .dropdown-menu { display: none; }
-.dropdown.open > .dropdown-menu { display: block; }
-.dropdown.open > .dropdown-toggle .arrow { transform: rotate(180deg); }
 
 /* Contenido interno */
 .dropdown-content {
@@ -674,53 +713,6 @@ nav ul li a:hover {
   color: #fff; text-decoration: none; font-weight: 600;
 }
 
-/* --- Responsive (móvil) --- */
-@media (max-width: 900px) {
-  .dropdown-menu {
-    position: static;   /* se integra al flujo del menú móvil */
-    display: none;      /* por defecto cerrado */
-    min-width: auto;
-    max-width: none;
-    width: 100%;
-    margin-top: 8px;
-    padding: 16px;
-    box-shadow: 0 6px 20px rgba(0,0,0,.06);
-    border-radius: 12px;
-  }
-  .dropdown.open > .dropdown-menu { display: block; }
-
-  .dropdown-content { display: block; } /* apilado */
-  .cta-card { margin-top: 16px; }
-
-  .nav-link { padding: 12px 14px; } /* área táctil */
-  /* Ocultar dropdown si el nav está colapsado */
-  .navbar:not(.is-open) .main-nav .dropdown-menu { display: none; }
-}
-
-
-/* --- Dropdown menu override (centered, responsive) --- */
-.dropdown-menu {
-  position: absolute;
-  top: calc(100% + 12px);
-  left: 50%;
-  transform: translateX(-50%);
-  width: clamp(720px, 88vw, 1100px);
-  max-width: calc(100vw - 24px);
-  padding: 32px;
-  background: #fff;
-  border-radius: 14px;
-  box-shadow: 0 12px 40px rgba(0,0,0,.12);
-  z-index: 50;
-}
-
-/* Show on hover (desktop) */
-@media (hover:hover) and (pointer:fine) {
-  .dropdown:hover > .dropdown-menu { display: block; }
-}
-
-/* Base hidden state; JS toggles visibility on mobile */
-.dropdown-menu { display: none; }
-.dropdown.open > .dropdown-menu { display: block; }
 
 /* Focus outline for accessibility */
 :focus-visible { outline: 2px solid rgba(59,130,246,.8); outline-offset: 3px; }

--- a/js/stacking.js
+++ b/js/stacking.js
@@ -53,43 +53,66 @@ window.addEventListener('load', revealCardsOnScroll);
       });
     }
 
-    // Dropdown behavior
-    document.querySelectorAll('.dropdown').forEach(dd => {
-      const toggle = dd.querySelector('.dropdown-toggle');
-      const menu = dd.querySelector('.dropdown-menu');
-      if (!toggle || !menu) return;
+      // Responsive dropdown fix
+      const DROPDOWN_SELECTOR = '.dropdown';
+      const TOGGLE_SELECTOR = '.dropdown-toggle';
+      const MENU_SELECTOR = '.dropdown-menu';
 
-      const open = () => {
-        dd.classList.add('open');
-        toggle.setAttribute('aria-expanded', 'true');
-      };
-      const close = () => {
+      // Responsive dropdown fix
+      function closeDropdown(dd) {
         dd.classList.remove('open');
-        toggle.setAttribute('aria-expanded', 'false');
-      };
+        const toggle = dd.querySelector(TOGGLE_SELECTOR);
+        if (toggle) toggle.setAttribute('aria-expanded', 'false');
+        document.body.classList.remove('menu-open');
+      }
 
-      toggle.addEventListener('click', (e) => {
-        e.preventDefault();
-        dd.classList.toggle('open');
-        const isOpen = dd.classList.contains('open');
-        toggle.setAttribute('aria-expanded', String(isOpen));
+      // Responsive dropdown fix
+      function openDropdown(dd) {
+        document.querySelectorAll(DROPDOWN_SELECTOR + '.open')
+          .forEach(o => o !== dd && closeDropdown(o));
+        dd.classList.add('open');
+        const toggle = dd.querySelector(TOGGLE_SELECTOR);
+        if (toggle) toggle.setAttribute('aria-expanded', 'true');
+        document.body.classList.add('menu-open');
+      }
+
+      // Responsive dropdown fix
+      document.querySelectorAll(DROPDOWN_SELECTOR).forEach(dd => {
+        const toggle = dd.querySelector(TOGGLE_SELECTOR);
+        const menu = dd.querySelector(MENU_SELECTOR);
+        if (!toggle || !menu) return;
+
+        toggle.addEventListener('click', (e) => {
+          e.preventDefault();
+          dd.classList.contains('open') ? closeDropdown(dd) : openDropdown(dd);
+        });
+
+        document.addEventListener('click', (e) => {
+          if (!dd.contains(e.target)) closeDropdown(dd);
+        });
+
+        dd.addEventListener('keydown', (e) => {
+          if (e.key === 'Escape') {
+            closeDropdown(dd);
+            toggle.focus();
+          }
+        });
+
+        menu.addEventListener('click', (e) => {
+          e.stopPropagation();
+        });
       });
 
-      // Click outside
-      document.addEventListener('click', (e) => {
-        if (!dd.contains(e.target)) {
-          close();
+      // Responsive dropdown fix
+      let lastIsMobile = window.matchMedia('(max-width: 768px)').matches;
+      window.addEventListener('resize', () => {
+        const isMobile = window.matchMedia('(max-width: 768px)').matches;
+        if (isMobile !== lastIsMobile) {
+          document.querySelectorAll(DROPDOWN_SELECTOR + '.open')
+            .forEach(dd => closeDropdown(dd));
+          lastIsMobile = isMobile;
         }
       });
-
-      // ESC to close
-      dd.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape') {
-          close();
-          toggle.focus();
-        }
-      });
-    });
   };
 
   if (document.readyState === 'complete') onLoad();


### PR DESCRIPTION
## Summary
- improve nav stacking context so dropdowns appear above hero
- add responsive mega-menu styles for desktop, tablet, and mobile
- implement JS dropdown controls with outside click, ESC, and resize handling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a89063ac2c8322bf712195955bed70