### PR TITLE
Remove unused CSS from styles.css

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -82,12 +82,6 @@ ul {
   max-width: 750px;   /* Ancho elegante */
 }
 
-/* Ajustes del texto centrado */
-.hero-text h1 {
-  font-size: 3.8rem;
-  line-height: 1.1;
-  margin-bottom: 22px;
-}
 
 .hero-text h1 {
   font-size: 3.4rem;
@@ -108,17 +102,6 @@ ul {
 }
 
 
-.hero-text p {
-  color: #e6e6e6;
-  font-size: 1.25rem;
-  line-height: 1.55;
-  margin-bottom: 18px;
-}
-
-.hero-text .hero-subtext {
-  color: #a8a8a8;
-  font-size: 1rem;
-}
 
 /* Animación del título */
 .floating-title {
@@ -143,20 +126,6 @@ ul {
 }
 
 
-.hero-images {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 15px;
-  flex: 1 1 45%;
-}
-
-.hero-images img {
-  width: 100%;
-  aspect-ratio: 1 / 1;
-  object-fit: cover;
-  border-radius: 16px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
-}
 
 /* --- Stack Scroll Effect (ACTUALIZADO) --- */
 .feature-split {
@@ -245,16 +214,6 @@ ul {
   text-transform: uppercase;
 }
 
-.stack-card .btn-outline {
-  margin-top: 20px;
-  display: inline-block;
-  padding: 12px 24px;
-  font-weight: 600;
-  font-size: 1rem;
-  border: 1px solid #111;
-  border-radius: 10px;
-  width: fit-content;
-}
 
 /* Responsive */
 @media (max-width: 768px) {
@@ -360,177 +319,6 @@ ul {
   margin-top: 10px;
 }
 
-/* Contenedor horizontal */
-.split-block.style-v2 {
-  display: flex;
-  flex-direction: row;
-  gap: 40px;
-  align-items: center;
-  justify-content: center;
-  padding: 60px 40px;
-  flex-wrap: wrap;
-}
-
-.split-block.style-v2 .split-image img {
-  max-width: 100%;
-  height: auto;
-  border-radius: 12px;
-  width: 600px;
-}
-
-/* Tarjeta de texto a la derecha */
-.split-block.style-v2 .card {
-  flex: 1;
-  max-width: 500px;
-  padding: 60px;
-  border-radius: 12px;
-  border: 1px solid #e0e0e0;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.03);
-  background-color: #ffffff;
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-}
-
-.card .label {
-  font-size: 0.8rem;
-  color: #ffffff;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.card .big-title {
-  font-size: 2.5rem;
-  font-weight: 800;
-  line-height: 1.2;
-  margin: 0;
-}
-
-.card .subtitle {
-  font-size: 1.1rem;
-  color: #ffffff;
-  line-height: 1.6;
-}
-
-.card .btn-outline.big {
-  margin-top: auto;
-  width: fit-content;
-  padding: 12px 24px;
-  font-weight: 600;
-  font-size: 1rem;
-  border: 1px solid #111;
-  border-radius: 10px;
-}
-
-/* Responsive para mobile */
-@media (max-width: 768px) {
-  .split-block.style-v2 {
-    flex-direction: column;
-    padding: 40px 20px;
-  }
-
-  .split-block.style-v2 .card {
-    padding: 30px;
-    text-align: center;
-  }
-
-  .card .btn-outline.big {
-    margin: 0 auto;
-  }
-
-  .split-block {
-    flex-direction: column;
-  }
-
-  .split-image {
-    flex: 1 1 100%;
-  }
-
-  .sticky-image {
-    position: static;
-    top: auto;
-  }
-
-  .split-text {
-    gap: 16px;
-    flex: 1 1 100%;
-    position: static;
-    min-height: auto;
-  }
-
-  .split-text .text-block {
-    padding: 20px;
-  }
-}
-
-/* --- Stack Scroll Effect --- */
-.feature-stack-section {
-  position: relative;
-  background: #000;
-  padding: 200px 0;
-}
-
-.stack-container {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 120px; /* espacio entre tarjetas */
-}
-
-.stack-card {
-  position: sticky;
-  top: 100px;
-  margin: 0 auto;
-  padding: 60px 40px;
-  border-radius: 20px;
-  background: #000;
-  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.08);
-  border: 1px solid #e0e0e0;
-  transform: scale(1);
-  z-index: 0;
-  pointer-events: auto;
-  transition: transform 0.4s ease;
-}
-
-
-.stack-card:not(:first-child) {
-  margin-top: -120px;
-}
-
-.stack-card.active {
-  transform: scale(1.02);
-}
-
-.stack-card.visible {
-  opacity: 1;
-  transform: scale(1);
-  pointer-events: auto;
-}
-
-.stack-card h2 {
-  font-size: 2rem;
-  margin: 0 0 10px;
-}
-
-.stack-card p {
-  font-size: 1.05rem;
-  color: #ffffff;
-  line-height: 1.6;
-  margin-bottom: 20px;
-}
-
-.stack-card .label {
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  color: #888;
-  margin-bottom: 10px;
-  font-weight: 600;
-}
-
-.stack-card .btn-outline {
-  margin-top: 20px;
-  display: inline-block;
-}
 
 /* Responsive */
 @media (max-width: 768px) {
@@ -576,8 +364,6 @@ ul {
     padding: 40px 20px;
   }
 
-  .hero-text,
-  .hero-images {
     flex: 1 1 100%;
   }
 
@@ -595,9 +381,6 @@ ul {
   }
 }
 
-@media (max-width: 480px) {
-  .hero-images {
-    grid-template-columns: 1fr;
   }
 }
 
@@ -821,17 +604,8 @@ nav ul li a:hover {
   transition: transform .35s ease, opacity .35s ease;
 }
 
-.stack-card.is-active > .card-inner{
-  transform: scale(1.02) translateY(-2px);
-  opacity: 1;
-}
 
 /* Avoid transforms on sticky ancestors */
-.split-block:not(.allow-transform){
-  transform: none !important;
-  perspective: none !important;
-  filter: none !important;
-}
 
 /* Prevent title wrapping jumps */
 .stack-card h2{
@@ -839,195 +613,6 @@ nav ul li a:hover {
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
   overflow: hidden;
-}
-
-/* Responsive audit */
-/* =========================================================
-   Responsive audit – base tokens
-========================================================= */
-:root{
-  --container-max: 1200px;
-  --gutter: clamp(12px, 2vw, 24px);
-  --radius: 14px;
-  --nav-h: 64px; /* Responsive audit */
-  /* Tipografía fluida */
-  --fs-h1: clamp(2rem, 2.8rem + 1vw, 4.25rem);
-  --fs-h2: clamp(1.4rem, 1.2rem + 1vw, 2.25rem);
-  --fs-body: clamp(0.98rem, 0.95rem + 0.3vw, 1.05rem);
-}
-
-/* Contenedor */
-.container,
-.wrapper,
-.section-inner {
-  width: min(100% - 2*var(--gutter), var(--container-max));
-  margin-inline: auto;
-}
-
-/* Imágenes y medios fluidos */
-img, video, canvas, svg {
-  max-width: 100%;
-  height: auto;
-}
-
-/* Evitar scroll horizontal por desbordes accidentales */
-html, body { overflow-x: clip; }
-html { scroll-behavior: smooth; }
-
-/* Tipografía */
-h1 { font-size: var(--fs-h1); line-height: 1.05; }
-h2 { font-size: var(--fs-h2); line-height: 1.15; }
-body { font-size: var(--fs-body); }
-
-/* =========================================================
-   Navbar y dropdown (desktop)
-========================================================= */
-.site-header, header, .main-nav { position: relative; z-index: 1000; }
-.main-nav, .main-nav > ul, .main-nav > ul > li { overflow: visible; }
-
-.dropdown-menu{
-  display: block;
-  position: absolute;
-  top: calc(100% + 12px);
-  left: 50%;
-  transform: translate(-50%, 8px);
-  width: clamp(720px, 88vw, 1200px);
-  max-width: calc(100vw - 24px);
-  margin-inline: 12px;
-  background: #000;
-  border-radius: var(--radius);
-  padding: 32px;
-  box-shadow: 0 12px 40px rgba(0,0,0,.12);
-  opacity: 0; visibility: hidden; pointer-events: none;
-  transition: opacity .2s ease, transform .2s ease;
-  z-index: 2000;
-}
-.dropdown.open > .dropdown-menu{
-  opacity: 1; visibility: visible; pointer-events: auto;
-  transform: translate(-50%, 0);
-}
-
-/* Si algún wrapper del nav aplicaba transform/filter, anúlalo para evitar stacking context */
-.navbar, .nav-container { transform: none; filter: none; }
-
-/* Secciones bajo el nav nunca deben tapar el menú */
-.hero, .hero-grid, .gallery-grid, .grid, .masonry {
-  position: relative; z-index: 1; overflow: visible;
-}
-
-/* =========================================================
-   Responsive: tablet y móvil
-========================================================= */
-@media (max-width: 1024px){
-  .dropdown-menu{ width: min(92vw, 820px); padding: 24px; }
-}
-
-@media (max-width: 768px){
-  /* Mega‑menu como panel full‑width fijo */
-  .dropdown-menu{
-    position: fixed;
-    top: var(--nav-h);
-    left: 0; right: 0;
-    transform: none;
-    width: 100vw; max-width: 100vw;
-    margin: 0;
-    border-radius: 12px;
-    padding: 20px;
-    max-height: calc(100vh - var(--nav-h) - 16px);
-    overflow: auto;
-    box-shadow: 0 12px 40px rgba(0,0,0,.18);
-  }
-  body.menu-open { overflow: hidden; }
-}
-
-/* === Responsive enhancements === */
-@media (max-width: 768px) {
-  .navbar {
-    flex-wrap: wrap;
-    padding: 20px;
-  }
-  .menu-toggle {
-    display: block;
-    color: #eee;
-  }
-  .main-nav {
-    display: none;
-    width: 100%;
-  }
-  .navbar.is-open .main-nav {
-    display: block;
-  }
-  .main-nav ul {
-    flex-direction: column;
-    gap: 10px;
-    padding: 10px 0;
-  }
-  .navbar.is-open .btn-primary {
-    width: 100%;
-    text-align: center;
-    margin-top: 10px;
-    display: block;
-  }
-  .hero {
-    flex-direction: column;
-    text-align: center;
-    padding: 40px 20px;
-  }
-  .hero-text,
-  .hero-images {
-    flex: 1 1 100%;
-  }
-  .hero-text h1 {
-    font-size: 2.5rem;
-  }
-  .feature-split .split-block.with-stack {
-    flex-direction: column;
-  }
-  .split-image,
-  .split-text {
-    flex: 1 1 100%;
-  }
-  .contact-content {
-    flex-direction: column;
-  }
-}
-
-@media (max-width: 480px) {
-  .navbar {
-    padding: 15px;
-  }
-  .hero-text h1 {
-    font-size: 2rem;
-  }
-  .hero-images {
-    grid-template-columns: 1fr;
-  }
-}
-
-/* =========================================================
-   Grillas/cards e imágenes
-========================================================= */
-.grid, .hero-grid, .cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 260px), 1fr));
-  gap: var(--gutter);
-}
-.card, .tile, .image-tile {
-  border-radius: var(--radius);
-  overflow: hidden;
-}
-.image-tile img{
-  width: 100%; height: 100%;
-  object-fit: cover;
-  aspect-ratio: 16/10;
-}
-
-/* Botones y targets touch */
-button, .btn, .nav-link { min-height: 40px; }
-
-/* Motion preferencia */
-@media (prefers-reduced-motion: reduce){
-  * { animation: none !important; transition: none !important; }
 }
 
 


### PR DESCRIPTION
## Summary
- remove duplicate hero typography definitions and unused hero image styles
- delete unused stack/card variants and related responsive rules
- trim unused navigation and layout helper styles to streamline the stylesheet

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a731f0be08322ac297506ae396ef4)