### PR TITLE
Simplify feature split into centered stack

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -358,52 +358,63 @@ body.menu-open {
    Feature split & stack cards
 ============================= */
 .feature-split {
-  padding: clamp(80px, 10vw, 120px) var(--gutter);
+  padding: clamp(96px, 12vw, 140px) var(--gutter);
 }
 
 .split-block {
   display: flex;
-  gap: clamp(32px, 4vw, 64px);
-  align-items: flex-start;
+  flex-direction: column;
+  gap: clamp(40px, 5vw, 72px);
+  align-items: center;
   max-width: 1200px;
   margin: 0 auto;
 }
 
-.split-image img {
-  width: 100%;
-  border-radius: 16px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
-}
-
-.sticky-image {
-  position: sticky;
-  top: 120px;
-  flex: 1 1 46%;
-  align-self: flex-start;
-}
-
 .split-text {
-  flex: 1 1 50%;
+  width: 100%;
+  max-width: 1040px;
   position: relative;
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(32px, 4vw, 56px);
+}
+
+.split-intro {
+  display: grid;
+  gap: 12px;
+  max-width: 760px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.split-intro h2 {
+  margin: 0;
+  font-size: clamp(2rem, 1.2vw + 1.8rem, 2.6rem);
+}
+
+.split-intro p {
+  margin: 0;
+  color: var(--text-muted);
 }
 
 .stack-container {
   display: flex;
   flex-direction: column;
-  gap: 80px;
+  gap: clamp(48px, 6vw, 96px);
 }
 
 .stack-card {
   position: sticky;
-  top: clamp(70px, 12vh, 140px);
+  top: clamp(80px, 14vh, 160px);
   margin: 0 auto;
   padding: 48px 40px;
   border-radius: 20px;
   background: var(--card-bg);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.4);
   opacity: 0;
-  transform: translateY(40px) scale(0.98);
+  transform: translateY(36px) scale(0.985);
   transition: all 0.5s ease;
   pointer-events: none;
 }
@@ -615,11 +626,6 @@ body.menu-open {
     flex-direction: column;
   }
 
-  .sticky-image {
-    position: relative;
-    top: auto;
-  }
-
   .stack-card {
     position: relative;
     top: auto;
@@ -662,6 +668,10 @@ body.menu-open {
 
   .hero-microcopy {
     font-size: 0.95rem;
+  }
+
+  .feature-split {
+    padding: 60px 18px;
   }
 
   .split-block {

--- a/index.html
+++ b/index.html
@@ -111,55 +111,53 @@
 
 
 
- <section id="about" class="feature-split"><!-- Responsive audit -->
-  <div class="split-block with-stack">
+  <section id="about" class="feature-split"><!-- Responsive audit -->
+    <div class="split-block with-stack">
 
-    <!-- Imagen fija a la izquierda -->
-    <div class="split-image sticky-image">
-      <img
-        src="src/office2.avif"
-        alt="Espacio de trabajo moderno" loading="lazy" decoding="async">
-    </div>
-
-    <!-- Textos apilables -->
-    <div class="split-text">
-      <div class="stack-container">
-           <div class="stack-card">
-          <div class="card-inner">
-            <p class="label">AUTOMATIZACIÓN CON IA</p>
-            <h2>Automatiza el trabajo. Acelera el crecimiento.</h2>
-            <p>Deja que la IA gestione las tareas repetitivas. Impulsa a tu equipo a enfocarse en innovación y resultados.</p>
-          </div>
+      <!-- Textos apilables -->
+      <div class="split-text">
+        <div class="split-intro">
+          <p class="label">AUTOMATIZACIÓN CON IA</p>
+          <h2>Automatiza el trabajo. Acelera el crecimiento.</h2>
+          <p>Asistentes de IA que escalan tu negocio automáticamente.</p>
         </div>
-
-        <div class="stack-card">
-          <div class="card-inner">
-            <p class="label">INTEGRACIÓN INSTANTÁNEA</p>
-            <h2>Conecta rápido con tu flujo</h2>
-            <p>Implementación fluida. Resultados al instante. Integra con tu CRM, chat y herramientas en minutos, no días.</p>
+        <div class="stack-container">
+          <div class="stack-card">
+            <div class="card-inner">
+              <p class="label">AUTOMATIZACIÓN CON IA</p>
+              <h2>Automatiza el trabajo. Acelera el crecimiento.</h2>
+              <p>Deja que la IA gestione las tareas repetitivas. Impulsa a tu equipo a enfocarse en innovación y resultados.</p>
+            </div>
           </div>
-        </div>
 
-        <div class="stack-card">
-          <div class="card-inner">
-            <p class="label">ALCANCE MULTICANAL</p>
-            <h2>Atiende en cada canal</h2>
-            <p>Estar donde están tus clientes. De WhatsApp a Instagram, ofrece soporte ágil y consistente con IA las 24/7.</p>
+          <div class="stack-card">
+            <div class="card-inner">
+              <p class="label">INTEGRACIÓN INSTANTÁNEA</p>
+              <h2>Conecta rápido con tu flujo</h2>
+              <p>Implementación fluida. Resultados al instante. Integra con tu CRM, chat y herramientas en minutos, no días.</p>
+            </div>
           </div>
-        </div>
 
-        <div class="stack-card">
-          <div class="card-inner">
-            <p class="label">ANALÍTICA EN VIVO</p>
-            <h2>Monitoriza. Mejora. Optimiza.</h2>
-            <p>Sigue el rendimiento en tiempo real. Usa los insights para optimizar y lograr mejores resultados.</p>
+          <div class="stack-card">
+            <div class="card-inner">
+              <p class="label">ALCANCE MULTICANAL</p>
+              <h2>Atiende en cada canal</h2>
+              <p>Estar donde están tus clientes. De WhatsApp a Instagram, ofrece soporte ágil y consistente con IA las 24/7.</p>
+            </div>
+          </div>
+
+          <div class="stack-card">
+            <div class="card-inner">
+              <p class="label">ANALÍTICA EN VIVO</p>
+              <h2>Monitoriza. Mejora. Optimiza.</h2>
+              <p>Sigue el rendimiento en tiempo real. Usa los insights para optimizar y lograr mejores resultados.</p>
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
-  </div>
-</section>
+    </div>
+  </section>
 
 
 


### PR DESCRIPTION
## Summary
- remove the split image column and add a centered intro ahead of the stacked cards
- restyle the feature section as a single-column story block with premium spacing and sticky cards
- clean up unused image-specific styles and tighten mobile padding for the section

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b1c52c33c832297252c60d40a6e54)