### PR TITLE
Add inline product demos for iAgency modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Sección "Nuestros productos" en `index.html` con cuatro tarjetas (FAQ, Pedidos, Turnos, Reservas) y demos de chat inline.
+- Estilos específicos para la grilla de productos y la UI de chat en `css/styles+v2.css`.
+- Lógica de demos conversacionales con sesiones persistentes y envío al webhook en `js/ia-products-demos.js`.
+
+### Cómo probar las demos
+1. Abrí `index.html` en el navegador y desplazate a la sección "Nuestros productos".
+2. En cada tarjeta, hacé clic en "Probar demo" para desplegar el chat embebido.
+3. Probá las chips rápidas o escribí un mensaje y presioná Enter o el botón "Enviar".
+4. Verificá que cada módulo envía al webhook con su `module` correspondiente y usa el `session_id` persistente en localStorage.

--- a/css/styles+v2.css
+++ b/css/styles+v2.css
@@ -952,3 +952,201 @@ body.menu-open {
   opacity: 0.7;
   cursor: wait;
 }
+
+/* =============================
+   Productos con demos
+============================= */
+.products {
+  padding: clamp(48px, 8vw, 96px) clamp(18px, 5vw, 72px);
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.products__header {
+  max-width: 760px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.products__subtitle {
+  color: var(--text-soft);
+  margin: 0;
+}
+
+.products__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(16px, 2vw, 22px);
+}
+
+.product-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-subtle);
+  border-radius: 18px;
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.3);
+}
+
+.product-card__description {
+  color: var(--text-soft);
+  margin-top: 6px;
+}
+
+.product-card__bullets {
+  display: grid;
+  gap: 8px;
+  padding-left: 16px;
+  color: var(--text-muted);
+}
+
+.product-card__bullets li {
+  list-style: disc;
+}
+
+.product-demo-toggle {
+  align-self: flex-start;
+  padding: 10px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-primary);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.product-demo-toggle:hover,
+.product-demo-toggle:focus-visible {
+  background: rgba(255, 255, 255, 0.07);
+  border-color: rgba(255, 255, 255, 0.16);
+  outline: none;
+}
+
+.product-demo {
+  border-top: 1px solid var(--border-subtle);
+  padding-top: 14px;
+  display: grid;
+  gap: 12px;
+}
+
+.chat-quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chat-chip {
+  border: 1px solid var(--border-subtle);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-primary);
+  border-radius: 20px;
+  padding: 8px 12px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.chat-chip:hover,
+.chat-chip:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.2);
+  outline: none;
+}
+
+.ia-chat-window {
+  background: #0a0a0a;
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  padding: 12px;
+  min-height: 180px;
+  display: grid;
+  gap: 8px;
+}
+
+.ia-chat-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 240px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.ia-chat-message {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  max-width: 100%;
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.ia-chat-message.user {
+  background: rgba(255, 255, 255, 0.06);
+  margin-left: auto;
+}
+
+.ia-chat-message.bot {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border-subtle);
+}
+
+.ia-chat-typing {
+  color: var(--text-soft);
+  font-size: 0.9rem;
+}
+
+.ia-chat-input {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  align-items: center;
+}
+
+.ia-chat-input input[type="text"] {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--text-primary);
+}
+
+.ia-chat-input input[type="text"]:focus-visible {
+  outline: 1px solid rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.ia-chat-input button[type="submit"] {
+  padding: 12px 18px;
+  border-radius: 12px;
+  border: 1px solid var(--border-subtle);
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.04));
+  color: var(--text-primary);
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.2s ease;
+}
+
+.ia-chat-input button[type="submit"]:hover,
+.ia-chat-input button[type="submit"]:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+  outline: none;
+}
+
+@media (max-width: 720px) {
+  .ia-chat-input {
+    grid-template-columns: 1fr;
+  }
+
+  .products {
+    padding-inline: clamp(16px, 5vw, 32px);
+  }
+}

--- a/index.html
+++ b/index.html
@@ -150,99 +150,228 @@
     </div>
   </section>
 
-
-
-<section id="contact" class="contact-section">
-  <div class="contact-inner">
-    <header class="contact-header">
-      <p class="contact-kicker">CONTACTO</p>
-      <h2>Construyamos tu asistente</h2>
-    </header>
-
-    <form id="contactForm" class="contact-form" action="https://formspree.io/f/xrbgpegn" method="POST">
-
-      <!-- fila 1 -->
-      <div class="contact-grid">
-        <div class="form-field">
-          <label for="nombre">Nombre y apellido</label>
-          <input type="text" id="nombre" name="nombre" required />
-        </div>
-
-        <div class="form-field">
-          <label for="email">Email</label>
-          <input type="email" id="email" name="email" required />
-        </div>
-      </div>
-
-      <!-- fila 2 -->
-      <div class="contact-grid">
-        <div class="form-field">
-          <label for="telefono">Teléfono</label>
-          <input type="tel" id="telefono" name="telefono" />
-        </div>
-
-        <div class="form-field">
-          <label for="empresa">Empresa</label>
-          <input type="text" id="empresa" name="empresa" />
-        </div>
-      </div>
-
-      <!-- texto libre -->
-      <div class="form-field">
-        <label for="mensaje">Cuéntanos sobre lo que quieres automatizar</label>
-        <textarea id="mensaje" name="mensaje" rows="4" required></textarea>
-      </div>
-
-      <!-- Mensajes de estado (corregidos con hidden) -->
-      <div class="contact-message contact-message--success"
-           id="contactSuccess"
-           aria-live="polite"
-           hidden>
-        Gracias, recibimos tu mensaje. Te contactaremos pronto 🙌
-      </div>
-
-      <div class="contact-message contact-message--error"
-           id="contactError"
-           aria-live="polite"
-           hidden>
-        Hubo un problema al enviar el formulario. Por favor, inténtalo de nuevo.
-      </div>
-
-      <div class="contact-actions">
-        <button type="button" class="contact-btn-secondary">Cancelar</button>
-        <button type="submit" class="contact-btn-primary" id="contactSubmitBtn">Enviar</button>
-      </div>
-
-      <p class="contact-hint">
-        Al enviar este formulario, nos autorizas a contactarte por email o teléfono.
-      </p>
-
-    </form>
-
-  </div>
-</section>
-
-
-
-  <footer class="footer" data-aos="fade-up">
-    <div class="footer-icons">
-      <!-- <span>📘</span>
-      <span>📷</span>
-      <span>𝕏</span>
-      <span>💼</span>
-      <span>▶️</span> -->
+  <section id="products" class="products">
+    <div class="products__header" data-aos="fade-up">
+      <p class="label">NUESTROS PRODUCTOS</p>
+      <h2>Probá nuestros módulos listos para usar</h2>
+      <p class="products__subtitle">Automatizá preguntas, pedidos, turnos y reservas con experiencias conversacionales en vivo.</p>
     </div>
-    <p>© 2025 iAgency. Todos los derechos reservados.</p>
-    <div class="footer-links">
-      <!-- <a href="#">Privacidad</a>
-      <a href="#">Términos</a>
-      <a href="#">Cookies</a> -->
-    </div>
-  </footer>
 
-  <script src="https://unpkg.com/aos@2.3.4/dist/aos.js" defer></script>
-  <script src="js/stacking.js" defer></script>
-  <script src="js/script.js"></script>
+    <div class="products__grid">
+      <article class="product-card" data-module="faq" data-aos="fade-up">
+        <div class="product-card__content">
+          <h3>Asistente FAQ</h3>
+          <p class="product-card__description">Responde preguntas frecuentes de forma consistente y sin esperar a un humano.</p>
+          <ul class="product-card__bullets">
+            <li>Disponible 24/7 con respuestas coherentes</li>
+            <li>Reduce mensajes repetidos y libera a tu equipo</li>
+            <li>Entrenable con tus políticas y tono de marca</li>
+            <li>Escala sin sumar costos operativos</li>
+          </ul>
+          <button class="product-demo-toggle" aria-expanded="false" aria-controls="demo-faq">Probar demo</button>
+        </div>
+        <div class="product-demo" id="demo-faq" hidden>
+          <div class="chat-quick-actions" aria-label="Preguntas rápidas">
+            <button type="button" class="chat-chip">¿Qué es iAgency?</button>
+            <button type="button" class="chat-chip">¿Qué incluye el módulo FAQ?</button>
+            <button type="button" class="chat-chip">¿Cuánto cuesta?</button>
+            <button type="button" class="chat-chip">¿Cómo se instala?</button>
+          </div>
+          <div class="ia-chat-window" role="region" aria-live="polite">
+            <div class="ia-chat-messages"></div>
+            <div class="ia-chat-typing" hidden>Escribiendo…</div>
+          </div>
+          <form class="ia-chat-input" novalidate>
+            <input type="text" name="message" placeholder="Escribí tu pregunta" autocomplete="off" required />
+            <button type="submit">Enviar</button>
+          </form>
+        </div>
+      </article>
+
+      <article class="product-card" data-module="pedidos" data-aos="fade-up">
+        <div class="product-card__content">
+          <h3>Módulo Pedidos</h3>
+          <p class="product-card__description">Toma pedidos, confirma detalles y mantiene actualizaciones automáticas.</p>
+          <ul class="product-card__bullets">
+            <li>Recibe pedidos y confirma disponibilidad</li>
+            <li>Calcula totales y tiempos estimados</li>
+            <li>Actualiza estado y deriva a humano si hace falta</li>
+            <li>Reduce errores en la toma manual</li>
+          </ul>
+          <button class="product-demo-toggle" aria-expanded="false" aria-controls="demo-pedidos">Probar demo</button>
+        </div>
+        <div class="product-demo" id="demo-pedidos" hidden>
+          <div class="chat-quick-actions" aria-label="Preguntas rápidas">
+            <button type="button" class="chat-chip">Quiero hacer un pedido</button>
+            <button type="button" class="chat-chip">¿Cómo funciona la confirmación?</button>
+            <button type="button" class="chat-chip">¿Puedo cancelar?</button>
+            <button type="button" class="chat-chip">¿Qué datos pedís?</button>
+          </div>
+          <div class="ia-chat-window" role="region" aria-live="polite">
+            <div class="ia-chat-messages"></div>
+            <div class="ia-chat-typing" hidden>Escribiendo…</div>
+          </div>
+          <form class="ia-chat-input" novalidate>
+            <input type="text" name="message" placeholder="Dejá tu consulta o pedido" autocomplete="off" required />
+            <button type="submit">Enviar</button>
+          </form>
+        </div>
+      </article>
+
+      <article class="product-card" data-module="turnos" data-aos="fade-up">
+        <div class="product-card__content">
+          <h3>Módulo Turnos</h3>
+          <p class="product-card__description">Agenda turnos, valida disponibilidad y confirma sin depender de agenda manual.</p>
+          <ul class="product-card__bullets">
+            <li>Valida horarios y confirma en segundos</li>
+            <li>Reprograma y avisa cambios automáticamente</li>
+            <li>Envía recordatorios para reducir ausencias</li>
+            <li>Compatible con flujos multicanal</li>
+          </ul>
+          <button class="product-demo-toggle" aria-expanded="false" aria-controls="demo-turnos">Probar demo</button>
+        </div>
+        <div class="product-demo" id="demo-turnos" hidden>
+          <div class="chat-quick-actions" aria-label="Preguntas rápidas">
+            <button type="button" class="chat-chip">Quiero reservar un turno</button>
+            <button type="button" class="chat-chip">¿Qué horarios hay?</button>
+            <button type="button" class="chat-chip">Quiero reprogramar</button>
+            <button type="button" class="chat-chip">¿Cómo confirmo?</button>
+          </div>
+          <div class="ia-chat-window" role="region" aria-live="polite">
+            <div class="ia-chat-messages"></div>
+            <div class="ia-chat-typing" hidden>Escribiendo…</div>
+          </div>
+          <form class="ia-chat-input" novalidate>
+            <input type="text" name="message" placeholder="Contanos qué turno necesitás" autocomplete="off" required />
+            <button type="submit">Enviar</button>
+          </form>
+        </div>
+      </article>
+
+      <article class="product-card" data-module="reservas" data-aos="fade-up">
+        <div class="product-card__content">
+          <h3>Módulo Reservas</h3>
+          <p class="product-card__description">Gestiona reservas para servicios, mesas o clases sin sumar fricción.</p>
+          <ul class="product-card__bullets">
+            <li>Recopila datos clave para reservar al instante</li>
+            <li>Confirma disponibilidad y envía comprobantes</li>
+            <li>Permite cancelar o modificar sin llamar</li>
+            <li>Reduce no-shows con notificaciones</li>
+          </ul>
+          <button class="product-demo-toggle" aria-expanded="false" aria-controls="demo-reservas">Probar demo</button>
+        </div>
+        <div class="product-demo" id="demo-reservas" hidden>
+          <div class="chat-quick-actions" aria-label="Preguntas rápidas">
+            <button type="button" class="chat-chip">Quiero hacer una reserva</button>
+            <button type="button" class="chat-chip">¿Qué datos necesitás?</button>
+            <button type="button" class="chat-chip">¿Puedo cancelar?</button>
+            <button type="button" class="chat-chip">¿Cómo recibo confirmación?</button>
+          </div>
+          <div class="ia-chat-window" role="region" aria-live="polite">
+            <div class="ia-chat-messages"></div>
+            <div class="ia-chat-typing" hidden>Escribiendo…</div>
+          </div>
+          <form class="ia-chat-input" novalidate>
+            <input type="text" name="message" placeholder="Chateá con el módulo de reservas" autocomplete="off" required />
+            <button type="submit">Enviar</button>
+          </form>
+        </div>
+      </article>
+    </div>
+  </section>
+
+  <section id="contact" class="contact-section">
+    <div class="contact-inner">
+      <header class="contact-header">
+        <p class="contact-kicker">CONTACTO</p>
+        <h2>Construyamos tu asistente</h2>
+      </header>
+
+      <form id="contactForm" class="contact-form" action="https://formspree.io/f/xrbgpegn" method="POST">
+
+        <!-- fila 1 -->
+        <div class="contact-grid">
+          <div class="form-field">
+            <label for="nombre">Nombre y apellido</label>
+            <input type="text" id="nombre" name="nombre" required />
+          </div>
+
+          <div class="form-field">
+            <label for="email">Email</label>
+            <input type="email" id="email" name="email" required />
+          </div>
+        </div>
+
+        <!-- fila 2 -->
+        <div class="contact-grid">
+          <div class="form-field">
+            <label for="telefono">Teléfono</label>
+            <input type="tel" id="telefono" name="telefono" />
+          </div>
+
+          <div class="form-field">
+            <label for="empresa">Empresa</label>
+            <input type="text" id="empresa" name="empresa" />
+          </div>
+        </div>
+
+        <!-- texto libre -->
+        <div class="form-field">
+          <label for="mensaje">Cuéntanos sobre lo que quieres automatizar</label>
+          <textarea id="mensaje" name="mensaje" rows="4" required></textarea>
+        </div>
+
+        <!-- Mensajes de estado (corregidos con hidden) -->
+        <div class="contact-message contact-message--success"
+             id="contactSuccess"
+             aria-live="polite"
+             hidden>
+          Gracias, recibimos tu mensaje. Te contactaremos pronto 🙌
+        </div>
+
+        <div class="contact-message contact-message--error"
+             id="contactError"
+             aria-live="polite"
+             hidden>
+          Hubo un problema al enviar el formulario. Por favor, inténtalo de nuevo.
+        </div>
+
+        <div class="contact-actions">
+          <button type="button" class="contact-btn-secondary">Cancelar</button>
+          <button type="submit" class="contact-btn-primary" id="contactSubmitBtn">Enviar</button>
+        </div>
+
+        <p class="contact-hint">
+          Al enviar este formulario, nos autorizas a contactarte por email o teléfono.
+        </p>
+
+      </form>
+
+    </div>
+  </section>
+
+
+
+    <footer class="footer" data-aos="fade-up">
+      <div class="footer-icons">
+        <!-- <span>📘</span>
+        <span>📷</span>
+        <span>𝕏</span>
+        <span>💼</span>
+        <span>▶️</span> -->
+      </div>
+      <p>© 2025 iAgency. Todos los derechos reservados.</p>
+      <div class="footer-links">
+        <!-- <a href="#">Privacidad</a>
+        <a href="#">Términos</a>
+        <a href="#">Cookies</a> -->
+      </div>
+    </footer>
+
+    <script src="https://unpkg.com/aos@2.3.4/dist/aos.js" defer></script>
+    <script src="js/stacking.js" defer></script>
+    <script src="js/ia-products-demos.js" defer></script>
+    <script src="js/script.js"></script>
 
 </body>
 

--- a/js/ia-products-demos.js
+++ b/js/ia-products-demos.js
@@ -1,0 +1,136 @@
+(function () {
+  const WEBHOOK_URL = "https://nicolasllanossw8.app.n8n.cloud/webhook/iagency/webchat";
+  const SESSION_KEY = "ia_session_id";
+
+  function ensureSessionId() {
+    try {
+      const stored = localStorage.getItem(SESSION_KEY);
+      if (stored) return stored;
+    } catch (err) {
+      console.warn("No se pudo leer localStorage", err);
+    }
+
+    const fallbackId = typeof crypto !== "undefined" && crypto.randomUUID
+      ? crypto.randomUUID()
+      : `ia-${Date.now()}`;
+
+    try {
+      localStorage.setItem(SESSION_KEY, fallbackId);
+    } catch (err) {
+      console.warn("No se pudo guardar el session_id", err);
+    }
+
+    return fallbackId;
+  }
+
+  function renderMessage(listEl, text, role) {
+    if (!listEl) return;
+    const message = document.createElement("div");
+    message.className = `ia-chat-message ${role}`;
+    message.textContent = text;
+    listEl.appendChild(message);
+    listEl.scrollTop = listEl.scrollHeight;
+  }
+
+  function toggleTyping(typingEl, isVisible) {
+    if (!typingEl) return;
+    typingEl.hidden = !isVisible;
+  }
+
+  function parseReply(data) {
+    if (!data) return "No pude responder eso. Probá reformular.";
+    return data.reply || data.respuesta || data.text || data.message || (typeof data === "string" ? data : "") || "No pude responder eso. Probá reformular.";
+  }
+
+  async function sendMessage(payload) {
+    const response = await fetch(WEBHOOK_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Error de red: ${response.status}`);
+    }
+
+    const contentType = response.headers.get("content-type") || "";
+    if (contentType.includes("application/json")) {
+      return response.json();
+    }
+    return response.text();
+  }
+
+  function createChatDemo(card, moduleName, sessionId) {
+    const demo = card.querySelector(".product-demo");
+    const toggleBtn = card.querySelector(".product-demo-toggle");
+    const messagesEl = card.querySelector(".ia-chat-messages");
+    const typingEl = card.querySelector(".ia-chat-typing");
+    const form = card.querySelector(".ia-chat-input");
+    const input = form ? form.querySelector("input[name='message']") : null;
+    const chips = card.querySelectorAll(".chat-chip");
+
+    if (!demo || !toggleBtn || !form || !input || !messagesEl) return;
+
+    toggleBtn.addEventListener("click", () => {
+      const isOpen = !demo.hidden;
+      demo.hidden = isOpen;
+      toggleBtn.setAttribute("aria-expanded", String(!isOpen));
+      toggleBtn.textContent = isOpen ? "Probar demo" : "Ocultar demo";
+    });
+
+    const handleSend = async (text) => {
+      const trimmed = text.trim();
+      if (!trimmed) return;
+
+      renderMessage(messagesEl, trimmed, "user");
+      input.value = "";
+      toggleTyping(typingEl, true);
+
+      const payload = {
+        message: trimmed,
+        session_id: sessionId,
+        business_id: "iagency",
+        page: window.location.pathname,
+        module: moduleName,
+      };
+
+      try {
+        const data = await sendMessage(payload);
+        const reply = parseReply(data);
+        renderMessage(messagesEl, reply, "bot");
+      } catch (err) {
+        console.error(err);
+        renderMessage(messagesEl, "Ahora mismo no estoy disponible. Probá de nuevo en unos segundos.", "bot");
+      } finally {
+        toggleTyping(typingEl, false);
+      }
+    };
+
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      handleSend(input.value);
+    });
+
+    input.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" && !event.shiftKey) {
+        event.preventDefault();
+        handleSend(input.value);
+      }
+    });
+
+    chips.forEach((chip) => {
+      chip.addEventListener("click", () => handleSend(chip.textContent || ""));
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const sessionId = ensureSessionId();
+    document.querySelectorAll(".product-card").forEach((card) => {
+      const moduleName = card.dataset.module;
+      if (!moduleName) return;
+      createChatDemo(card, moduleName, sessionId);
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
- add a new “Nuestros productos” section with four module cards and inline demos
- style the product grid and embedded chat UI to match the site’s dark theme
- implement reusable chat demo logic with persistent session IDs and webhook integration

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952d92829808322962a11781bd0dee0)