### PR TITLE
Fix mobile burger menu for Portfolio and add mobile edge padding

### DIFF
--- a/css/linear.css
+++ b/css/linear.css
@@ -900,8 +900,8 @@ textarea.contact-form-input {
   }
 
   .container {
-    padding-left: 20px;
-    padding-right: 20px;
+    padding-left: 24px;
+    padding-right: 24px;
   }
 
   .section {
@@ -1034,6 +1034,8 @@ textarea.contact-form-input {
 
   .project-info {
     position: static;
+    padding-left: 4px;
+    padding-right: 4px;
   }
 
   .project-carousel-wrapper {
@@ -1044,5 +1046,12 @@ textarea.contact-form-input {
     flex-direction: column;
     text-align: center;
     gap: 12px;
+  }
+}
+
+@media (max-width: 480px) {
+  .container {
+    padding-left: 26px;
+    padding-right: 26px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -1,44 +1,684 @@
-<!DOCTYPE html>
-<html lang="en">
+<!doctype html>
+<html lang="es">
+
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Hello I Agency</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>iAgency | Diseño de Sistemas Digitales</title>
+  <meta name="description"
+    content="Diseñamos software a medida, automatización y sistemas web para empresas de alto rendimiento." />
+  <meta name="robots" content="index, follow" />
+  <meta name="author" content="iAgency" />
+  <meta name="publisher" content="iAgency" />
+  <link rel="canonical" href="https://helloiagency.com/" />
+
+  <!-- Favicons -->
+  <link rel="icon" href="/favicon.ico" sizes="any" />
+  <link rel="apple-touch-icon" href="/favicon.ico" />
+  <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+  <link rel="manifest" href="/site.webmanifest" />
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="iAgency | Diseño de Sistemas Digitales" />
+  <meta property="og:description"
+    content="Diseñamos sistemas digitales para negocios: software a medida, automatización y plataformas web pensadas para optimizar operaciones y crecer con tecnología." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://helloiagency.com/" />
+  <meta property="og:site_name" content="iAgency" />
+  <meta property="og:locale" content="es_AR" />
+  <meta property="og:image" content="https://helloiagency.com/src/render.png" />
+  <meta property="og:image:alt" content="Muestra del Diseño de Sistemas Digitales de iAgency" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="iAgency | Diseño de Sistemas Digitales" />
+  <meta name="twitter:description"
+    content="Diseñamos sistemas digitales para negocios con software a medida, automatización y plataformas web." />
+  <meta name="twitter:image" content="https://helloiagency.com/src/render.png" />
+  <meta name="twitter:image:alt" content="iAgency - Digital Systems Studio" />
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-W33VWQRXSN"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag('js', new Date());
+    gtag('config', 'G-W33VWQRXSN');
+  </script>
+
+  <!-- Fonts: Montserrat -->
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400;1,500;1,600;1,700;1,800&display=swap"
+    rel="stylesheet" />
+
+  <!-- Icons -->
+  <script src="https://unpkg.com/@phosphor-icons/web"></script>
+
+  <!-- AOS Animations -->
+  <link href="https://unpkg.com/aos@2.3.4/dist/aos.css" rel="stylesheet" />
+
+  <!-- Linear Style Design System -->
+  <link rel="stylesheet" href="css/linear.css" />
+
+  <!-- Calendly -->
+  <link href="https://assets.calendly.com/assets/external/widget.css" rel="stylesheet" />
+
+  <style>
+    .page-view {
+      animation: fadeIn 0.4s ease-out forwards;
+    }
+
+    @keyframes fadeIn {
+      from {
+        opacity: 0;
+        transform: translateY(10px);
+      }
+
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+  </style>
 </head>
+
 <body>
-    <header>
-        <a href="/" aria-label="Home">
-            <img src="logo.png" alt="Logo">
-        </a>
-        <nav>
-            <ul>
-                <li><a href="/" aria-label="Home">Home</a></li>
-                <li><a href="#portfolio" aria-label="Portfolio">Portfolio</a></li>
-            </ul>
-        </nav>
+  <!-- Ambient Mesh Gradient -->
+  <div class="mesh-bg"></div>
+
+  <!-- NAVBAR GENERAL -->
+  <nav class="navbar" id="main-navbar">
+    <div class="container nav-content">
+      <div class="logo">
+        <a href="#" id="logo-home-link">iAgency</a>
+      </div>
+
+      <button class="mobile-toggle" aria-label="Abrir menú">
+        <i class="ph ph-list" style="font-size: 24px; color: var(--text-primary);"></i>
+      </button>
+
+      <ul class="nav-links" id="home-nav-links">
+        <li><a href="#" id="open-portfolio-link">Portfolio</a></li>
+        <li><a href="#soluciones">Soluciones</a></li>
+        <li><a href="#proceso">Proceso</a></li>
+        <li><a href="#contacto" class="btn btn-sm">Agendar llamada</a></li>
+      </ul>
+
+      <ul class="nav-links" id="portfolio-nav-links" style="display: none;">
+        <li><a href="#" id="back-home-link">Inicio</a></li>
+        <li><a href="#" class="active">Portfolio</a></li>
+        <li><a href="#" class="btn btn-sm" id="portfolio-contact-link">Agendar llamada</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <!-- VIEW: HOME -->
+  <div id="home-view" class="page-view">
+
+    <!-- HERO -->
+    <header class="section hero container">
+      <div class="hero-pill" data-aos="fade-down" data-aos-duration="800">
+        Digital Systems Studio
+      </div>
+
+      <h1 data-aos="fade-up" data-aos-duration="1000">
+        Tecnología que<br>impulsa negocios
+      </h1>
+
+      <p data-aos="fade-up" data-aos-duration="1000" data-aos-delay="100">
+        Ayudamos a negocios y organizaciones a incorporar tecnología en su operación mediante asesoría, desarrollo de
+        sistemas y automatización.
+      </p>
+
+      <div class="hero-actions w-full" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="200">
+        <a href="#soluciones" class="btn btn-outline">Ver soluciones</a>
+        <a href="#contacto" class="btn btn-primary">Agendar llamada</a>
+      </div>
     </header>
-    <main>
-        <form id="contact-form" aria-labelledby="contact-form-title">
-            <h2 id="contact-form-title">Contact Us</h2>
-            <label for="name" aria-label="Your Name">Name:</label>
-            <input type="text" id="name" name="name" required>
-            <label for="email" aria-label="Your Email">Email:</label>
-            <input type="email" id="email" name="email" required>
-            <button type="submit">Submit</button>
-        </form>
-        <script>
-            // Error handling for external CDN dependencies
-            const script = document.createElement('script');
-            script.src = 'https://cdn.example.com/script.js';
-            script.onerror = function() {
-                console.error('Failed to load the external script.');
-            };
-            document.head.appendChild(script);
-        </script>
-    </main>
-    <footer>
-        <a href="/privacy" aria-label="Privacy Policy">Privacy Policy</a>
-        <a href="/terms" aria-label="Terms of Service">Terms of Service</a>
+
+
+
+    <!-- SOLUTIONS (CARDS) -->
+    <section id="soluciones" class="section container">
+      <div class="features-header text-center" data-aos="fade-up">
+        <span class="label">Capacidades del estudio</span>
+        <h2>Sistemas a la medida de tu operación</h2>
+      </div>
+
+      <div class="grid-3">
+        <!-- Card 1 -->
+        <div class="card" data-aos="fade-up" data-aos-delay="100">
+          <div class="card-icon">
+            <i class="ph ph-globe-hemisphere-east" style="font-size: 24px"></i>
+          </div>
+          <h3>Plataformas Web</h3>
+          <p>Diseñamos entornos digitales estructurados para escalar tu presencia y centralizar tu negocio.</p>
+        </div>
+
+        <!-- Card 2 -->
+        <div class="card" data-aos="fade-up" data-aos-delay="200">
+          <div class="card-icon">
+            <i class="ph ph-code-block" style="font-size: 24px"></i>
+          </div>
+          <h3>Software a Medida</h3>
+          <p>Construimos herramientas exclusivas para organizar procesos y optimizar tu operación diaria.</p>
+        </div>
+
+        <!-- Card 3 -->
+        <div class="card" data-aos="fade-up" data-aos-delay="300">
+          <div class="card-icon">
+            <i class="ph ph-robot" style="font-size: 24px"></i>
+          </div>
+          <h3>Automatización e IA</h3>
+          <p>Conectamos sistemas asíncronos y asistentes inteligentes para eliminar trabajo manual repetitivo.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- PROCESS -->
+    <section id="proceso" class="section container">
+      <div class="features-header" data-aos="fade-up">
+        <span class="label">Nuestro Proceso</span>
+        <h2>Cómo abordamos y ejecutamos cada proyecto</h2>
+      </div>
+
+      <div class="process-grid" data-aos="fade-up" data-aos-delay="100">
+        <div class="step">
+          <span class="num">01.</span>
+          <h4>Entender</h4>
+          <p>Diagnosticamos la operación actual del negocio.</p>
+        </div>
+        <div class="step">
+          <span class="num">02.</span>
+          <h4>Proponer</h4>
+          <p>Diseñamos una arquitectura digital robusta.</p>
+        </div>
+        <div class="step">
+          <span class="num">03.</span>
+          <h4>Construir</h4>
+          <p>Desarrollamos iterativamente la plataforma o sistema.</p>
+        </div>
+        <div class="step">
+          <span class="num">04.</span>
+          <h4>Escalar</h4>
+          <p>Integramos y refinamos dinámicamente en producción.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- TEAM SECTION -->
+    <section id="equipo" class="section container">
+      <div class="features-header text-center" data-aos="fade-up">
+        <span class="label">Quiénes te ayudan</span>
+        <h2 style="font-size: 2.25rem; margin-bottom: 16px;">Expertos técnicos al servicio de tu visión.</h2>
+      </div>
+
+      <div class="grid-3" style="margin-top: 48px;">
+        <!-- Team Member 1 -->
+        <div class="card text-center" data-aos="fade-up" data-aos-delay="100" style="padding: 40px 24px;">
+          <div
+            style="width: 100%; height: 320px; border-radius: 16px; background: rgba(255,255,255,0.05); margin: 0 auto 32px; border: 1px solid var(--border-light); overflow: hidden; display: flex; align-items: center; justify-content: center;">
+            <img src="src/equipo/nicolas-llanos.jpg" alt="Nicolás Llanos"
+              style="width: 100%; height: 100%; object-fit: cover; object-position: top;">
+          </div>
+          <h3 style="margin-bottom: 8px; font-size: 1.5rem;">Nicolás Llanos</h3>
+          <p style="color: var(--text-tertiary); font-size: 1rem;">Cofundador · Desarrollo y Tecnología</p>
+        </div>
+
+        <!-- Team Member 2 -->
+        <div class="card text-center" data-aos="fade-up" data-aos-delay="200" style="padding: 40px 24px;">
+          <div
+            style="width: 100%; height: 320px; border-radius: 16px; background: rgba(255,255,255,0.05); margin: 0 auto 32px; border: 1px solid var(--border-light); overflow: hidden; display: flex; align-items: center; justify-content: center;">
+            <img src="src/equipo/marlene-morrone.png" alt="Marli"
+              style="width: 100%; height: 100%; object-fit: cover; object-position: top;">
+          </div>
+          <h3 style="margin-bottom: 8px; font-size: 1.5rem;">Marlene Morrone</h3>
+          <p style="color: var(--text-tertiary); font-size: 1rem;">Copropietaria · Comercial y Operaciones</p>
+        </div>
+
+        <!-- Team Member 3 -->
+        <div class="card text-center" data-aos="fade-up" data-aos-delay="300" style="padding: 40px 24px;">
+          <div
+            style="width: 100%; height: 320px; border-radius: 16px; background: rgba(255,255,255,0.05); margin: 0 auto 32px; border: 1px solid var(--border-light); overflow: hidden; display: flex; align-items: center; justify-content: center;">
+            <img src="src/equipo/mariano-oggier.png" alt="Mariano"
+              style="width: 100%; height: 100%; object-fit: cover; object-position: top;">
+          </div>
+          <h3 style="margin-bottom: 8px; font-size: 1.5rem;">Mariano Oggier</h3>
+          <p style="color: var(--text-tertiary); font-size: 1rem;">Desarrollo Estratégico y Crecimiento</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA -->
+    <section id="contacto" class="section container" style="padding-bottom: 80px;">
+      <div class="cta-box" data-aos="zoom-in" data-aos-duration="800">
+        <h2>Si tu negocio necesita una<br>mejor base digital, hablemos.</h2>
+        <p>Podemos ayudarte a diseñar una presencia, un sistema o una operación digital más clara, conectada y
+          escalable.</p>
+        <a href="#contacto-form" class="btn btn-primary" style="margin-top: 16px;">
+          Agendar llamada <i class="ph ph-arrow-right" style="margin-left: 8px;"></i>
+        </a>
+      </div>
+    </section>
+
+    <section id="contacto-form" class="container" style="padding-bottom: 80px;" data-aos="fade-up">
+      <div class="contact-layout">
+
+        <!-- Columna Izquierda: Info & Formulario -->
+        <div>
+          <span
+            style="color: var(--text-tertiary); font-size: 0.875rem; font-weight: 500; letter-spacing: 0.05em; text-transform: uppercase; margin-bottom: 12px; display: block;">Reunión
+            por Google Meet · 15 Min</span>
+          <h3 style="font-size: 2rem; margin-bottom: 16px;">Agendemos una llamada</h3>
+          <p style="color: var(--text-tertiary); margin-bottom: 32px; font-size: 1.125rem;">Analizamos tu
+            operación, detectamos oportunidades de mejora y definimos próximos pasos con claridad.</p>
+
+          <ul style="color: var(--text-tertiary); margin-bottom: 40px; padding-left: 20px; list-style-type: '✓  ';">
+            <li style="margin-bottom: 12px;">Diagnóstico rápido de procesos</li>
+            <li style="margin-bottom: 12px;">Definición de alcance y arquitectura</li>
+            <li>Plan de acción concreto y claro</li>
+          </ul>
+
+          <div
+            style="background: rgba(255,255,255,0.02); border: 1px solid var(--border-light); border-radius: 12px; padding: 32px;">
+
+            <h4 style="margin-bottom: 24px; font-size: 1.125rem;">¿Preferís que te contactemos primero?</h4>
+            <form action="https://formspree.io/f/xrbgpegn" method="POST" id="contactForm"
+              style="display: flex; flex-direction: column; gap: 16px;">
+              <div class="contact-inputs-row">
+                <input type="text" name="nombre" placeholder="Tu nombre" required class="contact-form-input">
+                <input type="text" name="contacto" placeholder="Email o WhatsApp" required class="contact-form-input">
+              </div>
+              <textarea name="mensaje" rows="3" placeholder="Contanos sobre tu negocio o consulta" required
+                class="contact-form-input"></textarea>
+              <button type="submit" class="btn btn-primary" id="contactSubmitBtn"
+                style="width: 100%; justify-content: center; margin-top: 8px;">Enviar mensaje</button>
+              <div class="contact-message contact-message--success" id="contactSuccess" aria-live="polite">
+                Gracias, pronto te contactaremos 🙌
+              </div>
+              <div class="contact-message contact-message--error" id="contactError" aria-live="polite">
+                Hubo un error. Por favor intentá de nuevo.
+              </div>
+            </form>
+          </div>
+        </div>
+
+        <!-- Columna Derecha: Calendly -->
+        <div>
+          <!-- Calendly INLINE WIDGET -->
+          <div class="calendly-inline-widget calendly-wrapper"
+            data-url="https://calendly.com/nicolasllanossw/reunion-15-min-iagency?hide_event_type_details=1&hide_gdpr_banner=1">
+          </div>
+        </div>
+
+      </div>
+    </section>
+
+    <!-- FOOTER -->
+    <footer class="container">
+      <div class="footer">
+        <div>© 2026 iAgency</div>
+        <div class="footer-links">
+          <a href="#">Privacidad</a>
+          <a href="#">Términos</a>
+        </div>
+      </div>
     </footer>
+
+    <!-- Scripts -->
+  </div>
+
+  <!-- VIEW: PORTFOLIO -->
+  <div id="portfolio-view" class="page-view" style="display: none;">
+
+    <!-- HEADER / HERO PORTFOLIO -->
+    <header class="section hero container">
+      <div class="hero-pill" data-aos="fade-down" data-aos-duration="800">
+        <i class="ph-fill ph-briefcase" style="margin-right: 6px; color: var(--text-primary)"></i> Nuestro
+        Trabajo
+      </div>
+      <h1 data-aos="fade-up" data-aos-duration="1000">
+        Proyectos que transforman<br>la operación digital
+      </h1>
+      <p data-aos="fade-up" data-aos-duration="1000" data-aos-delay="100">
+        Explora una selección de herramientas internas, automatizaciones integradas y plataformas web diseñadas
+        a
+        medida.
+      </p>
+    </header>
+
+    <!-- PROJECTS SECTION -->
+    <section class="section container" style="padding-top: 0; padding-bottom: 80px;">
+
+      <!-- ================= AGENTES DIGITALES ================= -->
+      <h2
+        style="font-size: 2rem; margin-top: 64px; margin-bottom: 32px; border-bottom: 1px solid var(--border-light); padding-bottom: 16px;">
+        Agentes Digitales</h2>
+      <div class="projects-container" style="margin-top: 0;">
+
+        <!-- 1) Sofi -->
+        <div class="project-row" data-aos="fade-up">
+          <div class="project-info">
+            <h3>Sofi</h3>
+            <p class="desc">Sofi es un sistema de automatización conversacional multicanal que centraliza y
+              optimiza la atención digital 24/7 en WhatsApp, Instagram, Facebook y Web, integrando APIs
+              oficiales de Meta, flujos en n8n e inteligencia artificial para reducir carga operativa y
+              mejorar la experiencia del cliente.</p>
+          </div>
+
+          <div class="project-carousel-wrapper"
+            data-images='["src/sofi/1.png", "src/sofi/2.png", "src/sofi/3.png", "src/sofi/4.png", "src/sofi/5.png", "src/sofi/6.png", "src/sofi/7.png", "src/sofi/8.png", "src/sofi/9.png"]'>
+          </div>
+        </div>
+
+        <!-- 2) Leo -->
+        <div class="project-row reverse" data-aos="fade-up">
+          <div class="project-info">
+            <h3>Leo</h3>
+            <p class="desc">Leo es un sistema de automatización conversacional orientado a ventas que
+              organiza y
+              confirma pedidos en WhatsApp e Instagram, integrando APIs oficiales de Meta, flujos en n8n y
+              lógica inteligente para estructurar órdenes automáticamente y optimizar procesos
+              comerciales.
+            </p>
+          </div>
+
+          <div class="project-carousel-wrapper"
+            data-images='["src/leo/1.png", "src/leo/2.png", "src/leo/3.png", "src/leo/4.png", "src/leo/5.png", "src/leo/6.png", "src/leo/7.png"]'>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- ================= SISTEMAS DE GESTIÓN ================= -->
+      <h2
+        style="font-size: 2rem; margin-top: 120px; margin-bottom: 32px; border-bottom: 1px solid var(--border-light); padding-bottom: 16px;">
+        Sistemas de Gestión</h2>
+      <div class="projects-container" style="margin-top: 0;">
+
+        <!-- 3) Sistema de Gestión de Pedidos y Producción -->
+        <div class="project-row" data-aos="fade-up">
+          <div class="project-info">
+            <h3>Sistema de Gestión de Pedidos y Producción</h3>
+            <p class="desc">Plataforma web premium orientada a negocios gastronómicos para la gestión
+              integral
+              de pedidos, control de stock por fecha y organización eficiente de los flujos de producción
+              y
+              despacho.</p>
+            <p class="desc">El sistema resuelve el clásico caos operativo mediante un catálogo dinámico y un
+              carrito de compras conectado a un panel de control central. Incluye interfaces dedicadas
+              basadas
+              en roles: un Dashboard administrativo para gestión y métricas, un Panel de Cocina enfocado
+              en
+              flujo de preparación, y una Vista de Despacho para envíos en tiempo real.</p>
+          </div>
+
+          <div class="project-carousel-wrapper" data-images='["src/dashboar.png"]'>
+          </div>
+        </div>
+
+
+        <!-- 4) Rebels Kite School Surf -->
+        <div class="project-row reverse" data-aos="fade-up">
+          <div class="project-info">
+            <h3>Rebels Kite School</h3>
+            <p class="desc">Sistema web de gestión desarrollado para escuelas de surf y kite, diseñado para
+              organizar clases, profesores, alumnos, pagos y facturación mediante un calendario
+              interactivo,
+              control de estados y paneles diferenciados por rol.</p>
+          </div>
+
+          <div class="project-carousel-wrapper"
+            data-images='["src/rebels/calendar.png", "src/rebels/login.png", "src/rebels/instructorManagement.png", "src/rebels/paymentsManagement.png", "src/rebels/biling.png"]'>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- ================= WEBS ================= -->
+      <h2
+        style="font-size: 2rem; margin-top: 120px; margin-bottom: 32px; border-bottom: 1px solid var(--border-light); padding-bottom: 16px;">
+        Webs Estratégicas</h2>
+      <div class="projects-container" style="margin-top: 0;">
+
+
+        <!-- 7) Inferno Growshop -->
+        <div class="project-row reverse" data-aos="fade-up">
+          <div class="project-info">
+            <h3>Inferno Growshop</h3>
+            <p class="desc">Sitio web de catálogo online diseñado para exhibir productos y permitir pedidos
+              mediante un carrito integrado con WhatsApp, ofreciendo una solución liviana y directa para
+              comercios que no requieren un e-commerce tradicional.</p>
+          </div>
+
+          <div class="project-carousel-wrapper"
+            data-images='["src/inferno/inferno1.png", "src/inferno/inferno2.png", "src/inferno/inferno3.png", "src/inferno/inferno4.png", "src/inferno/inferno5.png"]'>
+          </div>
+        </div>
+
+        <!-- 8) Eva Portfolio -->
+        <div class="project-row" data-aos="fade-up">
+          <div class="project-info">
+            <h3>Eva (Portfolio Artístico)</h3>
+            <p class="desc">Portfolio web minimalista y responsive desarrollado para una artista visual, con
+              enfoque en storytelling, protagonismo de imagen y navegación simple para destacar su obra de
+              forma clara y estética.</p>
+          </div>
+
+          <div class="project-carousel-wrapper"
+            data-images='["src/eva/eva.png", "src/eva/eva1.png", "src/eva/eva2.png"]'></div>
+        </div>
+
+      </div>
+    </section>
+
+    <!-- FOOTER -->
+    <footer class="container" style="margin-top: 80px;">
+      <div class="footer">
+        <div>© 2026 iAgency</div>
+        <div class="footer-links">
+          <a href="#">Privacidad</a>
+          <a href="#">Términos</a>
+        </div>
+      </div>
+    </footer>
+
+    <!-- Scripts -->
+  </div>
+
+  <!-- Scripts -->
+  <script src="https://unpkg.com/aos@2.3.4/dist/aos.js"></script>
+  <script src="https://assets.calendly.com/assets/external/widget.js" async></script>
+  <script src="js/script.js"></script>
+
+  <script>
+    AOS.init({
+      once: true,
+      offset: 50,
+      duration: 800,
+      easing: 'ease-out-cubic',
+    });
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const homeView = document.getElementById('home-view');
+      const portfolioView = document.getElementById('portfolio-view');
+
+      const homeNav = document.getElementById('home-nav-links');
+      const portfolioNav = document.getElementById('portfolio-nav-links');
+
+      const openPortfolioLink = document.getElementById('open-portfolio-link');
+      const backHomeLink = document.getElementById('back-home-link');
+      const portfolioContactLink = document.getElementById('portfolio-contact-link');
+
+      function scrollToTarget(selector, smooth = true) {
+        const target = document.querySelector(selector);
+        if (!target) return;
+
+        const headerOffset = 80;
+        const elementPosition = target.getBoundingClientRect().top;
+        const offsetPosition = elementPosition + window.pageYOffset - headerOffset;
+
+        window.scrollTo({
+          top: offsetPosition,
+          behavior: smooth ? 'smooth' : 'auto'
+        });
+      }
+
+      function showHome(scrollToSelector = null) {
+        homeView.style.display = 'block';
+        portfolioView.style.display = 'none';
+
+        homeNav.style.display = 'flex';
+        portfolioNav.style.display = 'none';
+
+        document.title = 'iAgency | Diseño de Sistemas Digitales';
+
+        setTimeout(() => {
+          if (typeof AOS !== 'undefined') {
+            AOS.refreshHard();
+          }
+
+          if (scrollToSelector) {
+            scrollToTarget(scrollToSelector, true);
+          } else {
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+          }
+        }, 50);
+      }
+
+      function showPortfolio() {
+        homeView.style.display = 'none';
+        portfolioView.style.display = 'block';
+
+        homeNav.style.display = 'none';
+        portfolioNav.style.display = 'flex';
+
+        document.title = 'iAgency | Portfolio';
+
+        setTimeout(() => {
+          if (typeof AOS !== 'undefined') {
+            AOS.refreshHard();
+          }
+          window.scrollTo({ top: 0, behavior: 'smooth' });
+        }, 50);
+      }
+
+      if (openPortfolioLink) {
+        openPortfolioLink.addEventListener('click', (e) => {
+          e.preventDefault();
+          showPortfolio();
+        });
+      }
+
+      if (backHomeLink) {
+        backHomeLink.addEventListener('click', (e) => {
+          e.preventDefault();
+          showHome();
+        });
+      }
+
+      if (portfolioContactLink) {
+        portfolioContactLink.addEventListener('click', (e) => {
+          e.preventDefault();
+          showHome('#contacto');
+        });
+      }
+
+      document.querySelectorAll('#home-nav-links a[href^="#"]').forEach(link => {
+        link.addEventListener('click', (e) => {
+          const href = link.getAttribute('href');
+          if (!href) return;
+
+          e.preventDefault();
+          scrollToTarget(href, true);
+        });
+      });
+    });
+  </script>
+
+  <script> // Carousel Script
+    // Initialize Carousels
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('.project-carousel-wrapper').forEach((wrapper) => {
+        try {
+          const images = JSON.parse(wrapper.dataset.images || '[]');
+          if (!images || images.length === 0) return;
+
+          let currentSlide = 0;
+
+          // Create track
+          const track = document.createElement('div');
+          track.className = 'carousel-track';
+          wrapper.appendChild(track);
+
+          // Add Slides
+          const slideEls = [];
+          images.forEach((src, idx) => {
+            const slide = document.createElement('div');
+            slide.className = 'carousel-slide' + (idx === 0 ? ' active' : '');
+            slide.style.backgroundImage = `url('${src}')`;
+            track.appendChild(slide);
+            slideEls.push(slide);
+          });
+
+          // Add Controls & Dots
+          if (images.length > 1) {
+            const controls = document.createElement('div');
+            controls.className = 'carousel-controls';
+
+            const prevBtn = document.createElement('button');
+            prevBtn.className = 'carousel-btn prev';
+            prevBtn.innerHTML = '<i class="ph ph-caret-left"></i>';
+            controls.appendChild(prevBtn);
+
+            const nextBtn = document.createElement('button');
+            nextBtn.className = 'carousel-btn next';
+            nextBtn.innerHTML = '<i class="ph ph-caret-right"></i>';
+            controls.appendChild(nextBtn);
+
+            wrapper.appendChild(controls);
+
+            const dotsContainer = document.createElement('div');
+            dotsContainer.className = 'carousel-dots';
+
+            const dotEls = [];
+            images.forEach((_, idx) => {
+              const dot = document.createElement('div');
+              dot.className = 'carousel-dot' + (idx === 0 ? ' active' : '');
+              dot.addEventListener('click', () => goToSlide(idx));
+              dotsContainer.appendChild(dot);
+              dotEls.push(dot);
+            });
+            wrapper.appendChild(dotsContainer);
+
+            // Logic
+            const goToSlide = (index) => {
+              slideEls[currentSlide].classList.remove('active');
+              dotEls[currentSlide].classList.remove('active');
+
+              currentSlide = index;
+              if (currentSlide < 0) currentSlide = images.length - 1;
+              if (currentSlide >= images.length) currentSlide = 0;
+
+              slideEls[currentSlide].classList.add('active');
+              dotEls[currentSlide].classList.add('active');
+            };
+
+            prevBtn.addEventListener('click', () => goToSlide(currentSlide - 1));
+            nextBtn.addEventListener('click', () => goToSlide(currentSlide + 1));
+          }
+
+        } catch (e) {
+          console.error("Error setting up carousel", e);
+        }
+      });
+    });
+  </script>
+
 </body>
+
 </html>

--- a/js/script.js
+++ b/js/script.js
@@ -25,18 +25,70 @@ function handleExternalError(error) {
     alert('An error occurred while loading external resources. Please try again later.');
 }
 
-// Example usage of validation functions
-const emailInput = document.getElementById('email');
-const phoneInput = document.getElementById('phone');
+// Initialize page interactions safely once DOM is ready
+document.addEventListener('DOMContentLoaded', function () {
+    // Example usage of validation functions (only when fields exist)
+    const emailInput = document.getElementById('email');
+    const phoneInput = document.getElementById('phone');
 
-emailInput.addEventListener('blur', function() {
-    if (!validateEmail(emailInput.value)) {
-        alert('Invalid email format!');
+    if (emailInput) {
+        emailInput.addEventListener('blur', function () {
+            if (!validateEmail(emailInput.value)) {
+                alert('Invalid email format!');
+            }
+        });
     }
-});
 
-phoneInput.addEventListener('blur', function() {
-    if (!validatePhone(phoneInput.value)) {
-        alert('Invalid phone number!');
+    if (phoneInput) {
+        phoneInput.addEventListener('blur', function () {
+            if (!validatePhone(phoneInput.value)) {
+                alert('Invalid phone number!');
+            }
+        });
+    }
+
+    // Mobile menu toggle (works for both home and portfolio nav variants)
+    const mobileToggle = document.querySelector('.mobile-toggle');
+    const navLists = Array.from(document.querySelectorAll('.nav-links'));
+
+    function getVisibleNav() {
+        return navLists.find(function (list) {
+            return window.getComputedStyle(list).display !== 'none';
+        }) || navLists[0];
+    }
+
+    function closeMobileMenu() {
+        const visibleNav = getVisibleNav();
+        if (!visibleNav) return;
+
+        visibleNav.classList.remove('active');
+        mobileToggle?.setAttribute('aria-expanded', 'false');
+    }
+
+    if (mobileToggle && navLists.length > 0) {
+        mobileToggle.setAttribute('aria-expanded', 'false');
+
+        mobileToggle.addEventListener('click', function () {
+            const visibleNav = getVisibleNav();
+            if (!visibleNav) return;
+
+            const isOpen = visibleNav.classList.toggle('active');
+            mobileToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        });
+
+        navLists.forEach(function (nav) {
+            nav.querySelectorAll('a').forEach(function (link) {
+                link.addEventListener('click', closeMobileMenu);
+            });
+        });
+
+        window.addEventListener('resize', function () {
+            if (window.innerWidth > 900) {
+                navLists.forEach(function (nav) {
+                    nav.classList.remove('active');
+                });
+                mobileToggle.setAttribute('aria-expanded', 'false');
+            }
+        });
     }
 });

--- a/js/script.js
+++ b/js/script.js
@@ -47,6 +47,36 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
+    // Preload project images early so portfolio carousels render faster on first open
+    const preloadFromCarouselData = function () {
+        const wrappers = document.querySelectorAll('.project-carousel-wrapper[data-images]');
+
+        wrappers.forEach(function (wrapper) {
+            let images = [];
+
+            try {
+                images = JSON.parse(wrapper.dataset.images || '[]');
+            } catch (error) {
+                console.warn('Invalid carousel data-images JSON', error);
+            }
+
+            images.forEach(function (src) {
+                if (!src) return;
+
+                const img = new Image();
+                img.decoding = 'async';
+                img.loading = 'eager';
+                img.src = src;
+            });
+        });
+    };
+
+    if ('requestIdleCallback' in window) {
+        window.requestIdleCallback(preloadFromCarouselData, { timeout: 1000 });
+    } else {
+        setTimeout(preloadFromCarouselData, 0);
+    }
+
     // Mobile menu toggle (works for both home and portfolio nav variants)
     const mobileToggle = document.querySelector('.mobile-toggle');
     const navLists = Array.from(document.querySelectorAll('.nav-links'));


### PR DESCRIPTION
### Motivation
- Fix a reported bug where the mobile burger menu did not open when viewing the Portfolio, and improve readability on small screens by reducing text hugging the screen edges.

### Description
- Restored the Home + Portfolio view structure in `index.html` and exposed both nav lists (`#home-nav-links` and `#portfolio-nav-links`) so the mobile menu can operate on the active view.
- Reworked `js/script.js` to initialize UI logic inside `DOMContentLoaded`, added defensive checks for optional fields (`#email`, `#phone`), and implemented a mobile menu controller that toggles the `.active` class on the currently visible `.nav-links`, closes the menu when a nav link is tapped, resets state on resize, and updates `aria-expanded` for accessibility.
- Adjusted mobile spacing in `css/linear.css` by increasing horizontal padding for `.container` at `max-width:900px` and `max-width:480px`, and adding small left/right padding to `.project-info` so portfolio text is not flush with the screen edge.

### Testing
- Checked JavaScript syntax with `node --check js/script.js`, which succeeded.
- Launched a local server (`python3 -m http.server 4173`) and ran an automated mobile verification with Playwright (emulated viewport `390x844`) to: open the Portfolio view, toggle the burger menu while in Portfolio, and capture a screenshot; the run succeeded and produced a screenshot artifact.
- Manual resize and link-click behavior were exercised in the Playwright run and observed to correctly open/close the mobile menu and close on nav link clicks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae9f4c7d1c8322817f45cb8a84b85c)