### PR TITLE
Arreglar menú burger en Portfolio y mejorar espaciado móvil en index-en

### DIFF
--- a/css/linear.css
+++ b/css/linear.css
@@ -900,8 +900,8 @@ textarea.contact-form-input {
   }
 
   .container {
-    padding-left: 24px;
-    padding-right: 24px;
+    padding-left: 30px;
+    padding-right: 30px;
   }
 
   .section {
@@ -1034,8 +1034,8 @@ textarea.contact-form-input {
 
   .project-info {
     position: static;
-    padding-left: 4px;
-    padding-right: 4px;
+    padding-left: 8px;
+    padding-right: 8px;
   }
 
   .project-carousel-wrapper {
@@ -1051,7 +1051,7 @@ textarea.contact-form-input {
 
 @media (max-width: 480px) {
   .container {
-    padding-left: 26px;
-    padding-right: 26px;
+    padding-left: 28px;
+    padding-right: 28px;
   }
 }

--- a/index-en.html
+++ b/index-en.html
@@ -522,12 +522,22 @@
                 });
             }
 
+            function resetMobileNavState() {
+                homeNav.classList.remove('active');
+                portfolioNav.classList.remove('active');
+                const mobileToggle = document.querySelector('.mobile-toggle');
+                if (mobileToggle) {
+                    mobileToggle.setAttribute('aria-expanded', 'false');
+                }
+            }
+
             function showHome(scrollToSelector = null) {
                 homeView.style.display = 'block';
                 portfolioView.style.display = 'none';
 
                 homeNav.style.display = 'flex';
                 portfolioNav.style.display = 'none';
+                resetMobileNavState();
 
                 document.title = 'iAgency | Digital Systems Studio';
 
@@ -550,6 +560,7 @@
 
                 homeNav.style.display = 'none';
                 portfolioNav.style.display = 'flex';
+                resetMobileNavState();
 
                 document.title = 'iAgency | Portfolio';
 

--- a/js/script.js
+++ b/js/script.js
@@ -80,18 +80,31 @@ document.addEventListener('DOMContentLoaded', function () {
     // Mobile menu toggle (works for both home and portfolio nav variants)
     const mobileToggle = document.querySelector('.mobile-toggle');
     const navLists = Array.from(document.querySelectorAll('.nav-links'));
+    const homeNav = document.getElementById('home-nav-links');
+    const portfolioNav = document.getElementById('portfolio-nav-links');
+    const homeView = document.getElementById('home-view');
+    const portfolioView = document.getElementById('portfolio-view');
 
     function getVisibleNav() {
+        const isPortfolioViewVisible = portfolioView && window.getComputedStyle(portfolioView).display !== 'none';
+
+        if (isPortfolioViewVisible && portfolioNav) {
+            return portfolioNav;
+        }
+
+        if (homeView && window.getComputedStyle(homeView).display !== 'none' && homeNav) {
+            return homeNav;
+        }
+
         return navLists.find(function (list) {
             return window.getComputedStyle(list).display !== 'none';
         }) || navLists[0];
     }
 
     function closeMobileMenu() {
-        const visibleNav = getVisibleNav();
-        if (!visibleNav) return;
-
-        visibleNav.classList.remove('active');
+        navLists.forEach(function (nav) {
+            nav.classList.remove('active');
+        });
         mobileToggle?.setAttribute('aria-expanded', 'false');
     }
 
@@ -101,6 +114,10 @@ document.addEventListener('DOMContentLoaded', function () {
         mobileToggle.addEventListener('click', function () {
             const visibleNav = getVisibleNav();
             if (!visibleNav) return;
+
+            navLists.forEach(function (nav) {
+                if (nav !== visibleNav) nav.classList.remove('active');
+            });
 
             const isOpen = visibleNav.classList.toggle('active');
             mobileToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
@@ -112,12 +129,15 @@ document.addEventListener('DOMContentLoaded', function () {
             });
         });
 
+        document.addEventListener('click', function (event) {
+            if (!event.target.closest('.navbar')) {
+                closeMobileMenu();
+            }
+        });
+
         window.addEventListener('resize', function () {
             if (window.innerWidth > 900) {
-                navLists.forEach(function (nav) {
-                    nav.classList.remove('active');
-                });
-                mobileToggle.setAttribute('aria-expanded', 'false');
+                closeMobileMenu();
             }
         });
     }


### PR DESCRIPTION
### Motivation
- Resolver que el botón de menú (burger) no respondía al usar la vista `Portfolio` en móvil y evitar que quede un estado activo/ARIA residual entre vistas. 
- Evitar que los textos y bloques queden demasiado pegados a los bordes en pantallas móviles mejorando el padding lateral.

### Description
- Mejorada la lógica de menú móvil en `js/script.js` para detectar de forma fiable qué nav está visible (`home` vs `portfolio`) con `getVisibleNav` y para cerrar otros menús antes de abrir el actual. 
- Añadida la función `resetMobileNavState()` en `index-en.html` y llamada desde `showHome` y `showPortfolio` para restablecer clases `active` y `aria-expanded` al cambiar de vista. 
- Añadido cierre del menú al hacer clic fuera de la barra (`document.addEventListener('click', ...)`) y refactor de `closeMobileMenu` para limpiar todos los `nav` y el estado ARIA. 
- Ajustado CSS móvil en `css/linear.css` incrementando el padding horizontal de `.container` y el inset de `.project-info` en los breakpoints móviles para mejorar separación de texto respecto a los bordes.

### Testing
- Levanté un servidor local con `python3 -m http.server 4173` y comprobé que la página y recursos devuelven `200` (éxito). (✅)
- Validación automatizada con Playwright en viewport móvil (390×844): se abrió `/index-en.html`, se abrió la vista `Portfolio`, se alternó el menú burger y se tomó una captura; el script finalizó correctamente y produjo `artifacts/index-en-mobile-portfolio-menu.png`. (✅)
- Revisado `git diff` y `git status`, y realizado commit con mensaje `Fix mobile portfolio menu and improve mobile text spacing on index-en` confirmando que los cambios en `index-en.html`, `js/script.js` y `css/linear.css` fueron aplicados. (✅)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aec91bb0c88322aec28f3da01de1fd)