### PR TITLE
Improve homepage conversion cues and unify portfolio navigation logic

### DIFF
--- a/css/linear.css
+++ b/css/linear.css
@@ -150,7 +150,7 @@ a {
   font-size: 0.875rem;
   color: var(--text-primary);
   font-weight: 500;
-  transition: opacity 0.2s ease;
+  transition: opacity 0.2s ease, color 0.2s ease;
 }
 
 .mobile-toggle {
@@ -165,6 +165,28 @@ a {
 .nav-links a:hover,
 .nav-links a.active {
   opacity: 0.7;
+}
+
+.nav-links a[href="#portfolio"] {
+  position: relative;
+}
+
+.nav-links a[href="#portfolio"]::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -6px;
+  width: 100%;
+  height: 1px;
+  background: var(--text-secondary);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.nav-links a[href="#portfolio"]:hover::after,
+.nav-links a[href="#portfolio"]:focus-visible::after,
+.nav-links a[href="#portfolio"].is-active::after {
+  opacity: 1;
 }
 
 .btn-sm {
@@ -221,6 +243,14 @@ a {
   font-weight: 500;
 }
 
+.hero-intro-line {
+  margin: 0 0 14px;
+  font-size: 0.9rem;
+  letter-spacing: 0.01em;
+  color: var(--text-secondary);
+  max-width: 560px;
+}
+
 .hero h1 {
   font-size: clamp(2.25rem, 6vw, 4.5rem);
   max-width: 900px;
@@ -247,6 +277,90 @@ a {
   display: flex;
   gap: 16px;
   justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 18px;
+}
+
+.btn-portfolio {
+  border-color: rgba(255, 255, 255, 0.28);
+}
+
+.btn-portfolio:hover {
+  border-color: rgba(255, 255, 255, 0.45);
+}
+
+.hero-scroll-cue {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.86rem;
+  color: var(--text-secondary);
+  margin-bottom: 16px;
+}
+
+.hero-scroll-cue i {
+  font-size: 0.95rem;
+  transition: transform 0.2s ease;
+}
+
+.hero-scroll-cue:hover i,
+.hero-scroll-cue:focus-visible i {
+  transform: translateY(2px);
+}
+
+.hero-proof-strip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+.hero-proof-strip span {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  border: 1px solid var(--border-light);
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.portfolio-quick-access {
+  padding-top: 0;
+  padding-bottom: 12px;
+}
+
+.portfolio-quick-access__box {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 18px;
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  padding: 18px;
+  background: rgba(255, 255, 255, 0.015);
+}
+
+.portfolio-quick-access__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-tertiary);
+}
+
+.portfolio-quick-access__box h2 {
+  font-size: 1.3rem;
+  margin-bottom: 6px;
+}
+
+.portfolio-quick-access__box p {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.btn-portfolio-inline {
+  white-space: nowrap;
 }
 
 @keyframes fadeInDown {
@@ -291,6 +405,12 @@ a {
 .btn-outline:hover {
   background: rgba(255, 255, 255, 0.08);
   border-color: var(--border-glow);
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.55);
+  outline-offset: 3px;
 }
 
 /* =========================================
@@ -819,9 +939,72 @@ a {
 }
 
 @media (max-width: 600px) {
+  .hero {
+    min-height: auto;
+    padding-top: calc(var(--nav-h) + 20px);
+    padding-bottom: 56px;
+  }
+
+  .hero-kicker {
+    margin-bottom: 8px;
+  }
+
+  .hero-pill {
+    margin-bottom: 18px;
+  }
+
+  .hero-intro-line {
+    margin-bottom: 10px;
+    font-size: 0.82rem;
+  }
+
+  .hero h1 {
+    margin-bottom: 14px;
+  }
+
+  .hero p {
+    margin-top: 4px;
+    margin-bottom: 20px;
+  }
+
   .hero-actions {
     flex-direction: column;
     width: 100%;
+    gap: 10px;
+    margin-bottom: 12px;
+  }
+
+  .hero-actions .btn-portfolio {
+    border-color: rgba(255, 255, 255, 0.42);
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .hero-scroll-cue {
+    margin-bottom: 12px;
+  }
+
+  .hero-proof-strip {
+    justify-content: flex-start;
+    width: 100%;
+    gap: 8px;
+  }
+
+  .hero-proof-strip span {
+    font-size: 0.74rem;
+    padding: 5px 9px;
+  }
+
+  .portfolio-quick-access__box {
+    grid-template-columns: 1fr;
+    align-items: start;
+    gap: 12px;
+    padding: 16px;
+  }
+
+  .portfolio-quick-access__box h2 {
+    text-align: left;
+    margin-left: 0;
+    margin-right: 0;
   }
 
   .btn {

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
   <nav class="navbar" id="main-navbar">
     <div class="container nav-content">
       <div class="logo">
-        <a href="#" id="logo-home-link" title="Leba - Inicio">Leba</a>
+        <a href="#home" id="logo-home-link" title="Leba - Inicio" aria-label="Volver al inicio">Leba</a>
       </div>
 
       <button class="mobile-toggle" aria-label="Abrir menú">
@@ -124,7 +124,7 @@
       </button>
 
       <ul class="nav-links" id="home-nav-links">
-        <li><a href="#" id="open-portfolio-link" title="Ver portfolio de proyectos" data-track-cta="click_nav_portfolio"
+        <li><a href="#portfolio" id="open-portfolio-link" title="Ver portfolio de proyectos" aria-label="Abrir portfolio de proyectos" data-track-cta="click_nav_portfolio"
             data-track-section="navbar" data-track-type="navigation">Portfolio</a></li>
         <li><a href="#soluciones" title="Ver nuestras soluciones" data-track-cta="click_nav_soluciones"
             data-track-section="navbar" data-track-type="navigation">Soluciones</a></li>
@@ -150,13 +150,16 @@
         Digital Systems Studio
       </div>
 
+      <p class="hero-intro-line" data-aos="fade-up" data-aos-duration="900" data-aos-delay="150">
+        We build digital systems for real operations.
+      </p>
+
       <h1 data-aos="fade-up" data-aos-duration="1000" data-aos-delay="200">
-        Diseñamos sistemas digitales que organizan y potencian negocios
+        Tecnología que impulsa negocios
       </h1>
 
       <p data-aos="fade-up" data-aos-duration="1000" data-aos-delay="300">
-        Ayudamos a negocios y emprendedores a estructurar su operación mediante software a medida, automatización e
-        integración de herramientas.
+        Diseñamos software a medida, automatizaciones e integraciones para ordenar tu operación y escalar con claridad.
       </p>
 
       <div class="hero-actions w-full" data-aos="fade-up" data-aos-duration="1000" data-aos-delay="400">
@@ -166,9 +169,35 @@
         <a href="#soluciones" class="btn btn-outline" title="Ver las soluciones de Leba"
           data-track-cta="click_explorar_soluciones" data-track-section="hero" data-track-type="cta"
           data-track-label="hero_secondary_soluciones">Explorar soluciones</a>
+        <a href="#portfolio" class="btn btn-outline btn-portfolio" title="Ver portfolio de proyectos" aria-label="Ver portfolio de proyectos"
+          data-portfolio-trigger="true" data-track-cta="click_hero_portfolio" data-track-section="hero"
+          data-track-type="cta" data-track-label="hero_portfolio_cta">Ver portfolio</a>
+      </div>
+
+      <a href="#soluciones" class="hero-scroll-cue" data-scroll-target="#soluciones" aria-label="Explorar más abajo">
+        <span>Explorar más abajo</span>
+        <i class="ph ph-arrow-down"></i>
+      </a>
+
+      <div class="hero-proof-strip" aria-label="Razones para elegir Leba">
+        <span>Sistemas a medida</span>
+        <span>Automatización e IA</span>
+        <span>Plataformas operativas</span>
       </div>
     </header>
 
+    <section class="portfolio-quick-access section container" aria-label="Acceso rápido al portfolio">
+      <div class="portfolio-quick-access__box" data-aos="fade-up" data-aos-duration="800">
+        <p class="portfolio-quick-access__label">Recorré casos reales</p>
+        <div>
+          <h2>¿Querés ver cómo se aplican estas soluciones?</h2>
+          <p>Entrá al portfolio y explorá proyectos diseñados para operaciones reales.</p>
+        </div>
+        <a href="#portfolio" class="btn btn-outline btn-portfolio-inline" aria-label="Abrir portfolio desde acceso rápido"
+          data-portfolio-trigger="true" data-track-cta="click_inline_portfolio" data-track-section="home_inline"
+          data-track-type="cta" data-track-label="inline_portfolio_access">Ver portfolio</a>
+      </div>
+    </section>
 
 
     <!-- SOLUTIONS (CARDS) -->
@@ -740,129 +769,6 @@
       offset: 50,
       duration: 800,
       easing: 'ease-out-cubic',
-    });
-
-    document.addEventListener('DOMContentLoaded', () => {
-      const homeView = document.getElementById('home-view');
-      const portfolioView = document.getElementById('portfolio-view');
-
-      const homeNav = document.getElementById('home-nav-links');
-      const portfolioNav = document.getElementById('portfolio-nav-links');
-
-      const openPortfolioLink = document.getElementById('open-portfolio-link');
-      const backHomeLink = document.getElementById('back-home-link');
-      const portfolioContactLink = document.getElementById('portfolio-contact-link');
-      const logoHomeLink = document.getElementById('logo-home-link');
-
-      // Support deep-linking to portfolio or other sections
-      function handleInitialHash() {
-        if (window.location.hash === '#portfolio') {
-          showPortfolio();
-        } else if (window.location.hash && window.location.hash !== '#') {
-          // If it's another hash (like #soluciones), ensure home is visible and scroll
-          showHome(window.location.hash);
-        }
-      }
-
-      function scrollToTarget(selector, smooth = true) {
-        const target = document.querySelector(selector);
-        if (!target) return;
-
-        const headerOffset = 80;
-        const elementPosition = target.getBoundingClientRect().top;
-        const offsetPosition = elementPosition + window.pageYOffset - headerOffset;
-
-        window.scrollTo({
-          top: offsetPosition,
-          behavior: smooth ? 'smooth' : 'auto'
-        });
-      }
-
-      function showHome(scrollToSelector = null) {
-        window.scrollTo({ top: 0, behavior: 'instant' });
-
-        homeView.style.display = 'block';
-        portfolioView.style.display = 'none';
-
-        if (homeNav) homeNav.style.display = 'flex';
-        // if (portfolioNav) portfolioNav.style.display = 'none';
-
-        document.title = 'Leba | Diseño de Sistemas Digitales';
-
-        setTimeout(() => {
-          if (typeof AOS !== 'undefined') {
-            AOS.refreshHard();
-          }
-
-          if (scrollToSelector) {
-            scrollToTarget(scrollToSelector, false);
-          }
-        }, 50);
-      }
-
-      function showPortfolio() {
-        window.scrollTo({ top: 0, behavior: 'instant' });
-
-        homeView.style.display = 'none';
-        portfolioView.style.display = 'block';
-
-        if (homeNav) homeNav.style.display = 'flex'; // Keep the same nav visible
-        // if (portfolioNav) portfolioNav.style.display = 'flex';
-
-        document.title = 'Leba | Portfolio';
-
-        setTimeout(() => {
-          if (typeof AOS !== 'undefined') {
-            AOS.refreshHard();
-          }
-        }, 50);
-      }
-
-      if (openPortfolioLink) {
-        openPortfolioLink.addEventListener('click', (e) => {
-          e.preventDefault();
-          showPortfolio();
-        });
-      }
-
-      if (backHomeLink) {
-        backHomeLink.addEventListener('click', (e) => {
-          e.preventDefault();
-          showHome();
-        });
-      }
-
-      if (logoHomeLink) {
-        logoHomeLink.addEventListener('click', (e) => {
-          e.preventDefault();
-          showHome();
-        });
-      }
-
-      if (portfolioContactLink) {
-        portfolioContactLink.addEventListener('click', (e) => {
-          e.preventDefault();
-          showHome('#contacto');
-        });
-      }
-
-      document.querySelectorAll('.nav-links a[href^="#"]').forEach(link => {
-        link.addEventListener('click', (e) => {
-          const href = link.getAttribute('href');
-          if (!href || href === '#') return;
-
-          e.preventDefault();
-
-          if (portfolioView.style.display === 'block') {
-            showHome(href);
-          } else {
-            scrollToTarget(href, true);
-          }
-        });
-      });
-
-      // Handle initial hash on load
-      handleInitialHash();
     });
   </script>
 

--- a/js/script.js
+++ b/js/script.js
@@ -81,17 +81,16 @@ document.addEventListener('DOMContentLoaded', function () {
     const mobileToggle = document.querySelector('.mobile-toggle');
     const navLists = Array.from(document.querySelectorAll('.nav-links'));
     const homeNav = document.getElementById('home-nav-links');
-    const portfolioNav = document.getElementById('portfolio-nav-links');
     const homeView = document.getElementById('home-view');
     const portfolioView = document.getElementById('portfolio-view');
+    const logoHomeLink = document.getElementById('logo-home-link');
+    const backHomeLink = document.getElementById('back-home-link');
+    const portfolioContactLink = document.getElementById('portfolio-contact-link');
+    const defaultTitle = 'Leba | Diseño de Sistemas Digitales';
+    const portfolioTitle = 'Leba | Portfolio';
+    const navHashTargets = new Set(['#soluciones', '#proceso', '#contacto', '#contacto-form']);
 
     function getVisibleNav() {
-        const isPortfolioViewVisible = portfolioView && window.getComputedStyle(portfolioView).display !== 'none';
-
-        if (isPortfolioViewVisible && portfolioNav) {
-            return portfolioNav;
-        }
-
         if (homeView && window.getComputedStyle(homeView).display !== 'none' && homeNav) {
             return homeNav;
         }
@@ -141,6 +140,148 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         });
     }
+
+    function refreshAnimations() {
+        if (typeof AOS !== 'undefined' && typeof AOS.refreshHard === 'function') {
+            AOS.refreshHard();
+        }
+    }
+
+    function scrollToTarget(selector, smooth = true) {
+        if (!selector || selector === '#') return;
+        const target = document.querySelector(selector);
+        if (!target) return;
+
+        const headerOffset = 80;
+        const offsetPosition = target.getBoundingClientRect().top + window.pageYOffset - headerOffset;
+        window.scrollTo({
+            top: offsetPosition,
+            behavior: smooth ? 'smooth' : 'auto'
+        });
+    }
+
+    function showHome(options = {}) {
+        const target = options.target || null;
+        const smooth = options.smooth !== false;
+        const updateHash = options.updateHash !== false;
+
+        if (homeView) homeView.style.display = 'block';
+        if (portfolioView) portfolioView.style.display = 'none';
+        if (homeNav) homeNav.style.display = 'flex';
+
+        document.title = defaultTitle;
+        closeMobileMenu();
+        window.scrollTo({ top: 0, behavior: 'auto' });
+
+        if (updateHash) {
+            const nextHash = target && navHashTargets.has(target) ? target : '';
+            history.replaceState(null, '', nextHash || (window.location.pathname + window.location.search));
+        }
+
+        setTimeout(function () {
+            refreshAnimations();
+            if (target) {
+                scrollToTarget(target, smooth);
+            }
+        }, 50);
+    }
+
+    function showPortfolio(options = {}) {
+        const updateHash = options.updateHash !== false;
+
+        if (homeView) homeView.style.display = 'none';
+        if (portfolioView) portfolioView.style.display = 'block';
+        if (homeNav) homeNav.style.display = 'flex';
+
+        document.title = portfolioTitle;
+        closeMobileMenu();
+        window.scrollTo({ top: 0, behavior: 'auto' });
+
+        if (updateHash) {
+            history.replaceState(null, '', '#portfolio');
+        }
+
+        setTimeout(refreshAnimations, 50);
+    }
+
+    window.showHome = showHome;
+    window.showPortfolio = showPortfolio;
+    window.scrollToTarget = scrollToTarget;
+    window.closeMobileMenu = closeMobileMenu;
+
+    function handleInitialRouteFromHash() {
+        const hash = window.location.hash;
+        if (hash === '#portfolio') {
+            showPortfolio({ updateHash: false });
+            return;
+        }
+
+        if (hash && navHashTargets.has(hash)) {
+            showHome({ target: hash, smooth: false, updateHash: false });
+            return;
+        }
+
+        showHome({ updateHash: false });
+    }
+
+    document.querySelectorAll('[data-portfolio-trigger], #open-portfolio-link').forEach(function (trigger) {
+        trigger.addEventListener('click', function (event) {
+            event.preventDefault();
+            showPortfolio();
+        });
+    });
+
+    if (logoHomeLink) {
+        logoHomeLink.addEventListener('click', function (event) {
+            event.preventDefault();
+            showHome();
+        });
+    }
+
+    if (backHomeLink) {
+        backHomeLink.addEventListener('click', function (event) {
+            event.preventDefault();
+            showHome();
+        });
+    }
+
+    if (portfolioContactLink) {
+        portfolioContactLink.addEventListener('click', function (event) {
+            event.preventDefault();
+            showHome({ target: '#contacto' });
+        });
+    }
+
+    document.querySelectorAll('a[href^="#"], [data-scroll-target]').forEach(function (link) {
+        link.addEventListener('click', function (event) {
+            const target = link.getAttribute('data-scroll-target') || link.getAttribute('href');
+            if (!target || target === '#' || target === '#portfolio') return;
+            if (!target.startsWith('#')) return;
+
+            event.preventDefault();
+
+            if (portfolioView && window.getComputedStyle(portfolioView).display !== 'none') {
+                showHome({ target: target });
+            } else {
+                scrollToTarget(target, true);
+                if (navHashTargets.has(target)) {
+                    history.replaceState(null, '', target);
+                }
+                closeMobileMenu();
+            }
+        });
+    });
+
+    window.addEventListener('hashchange', function () {
+        if (window.location.hash === '#portfolio') {
+            showPortfolio({ updateHash: false });
+        } else if (navHashTargets.has(window.location.hash)) {
+            showHome({ target: window.location.hash, smooth: false, updateHash: false });
+        }
+    });
+
+    handleInitialRouteFromHash();
+
     // Centralized Tracking Architecture
     document.addEventListener('click', function (e) {
         const trackEl = e.target.closest('[data-track-cta]');


### PR DESCRIPTION
### Motivation
- Reduce friction for first-time visitors by making Portfolio access more obvious and giving the hero clear, scannable guidance to the next steps. 
- Keep the current dark premium aesthetic and existing view-switching behavior while preventing accidental/duplicate click behaviors and improving mobile first-screen usability.

### Description
- Updated `index.html` to add a subtle brand intro line above the main headline, sharpened the hero copy, added a dedicated "Ver portfolio" hero CTA, a subtle scroll cue to `#soluciones`, and a compact proof strip (three short trust/value items), while preserving existing text sections and AOS attributes. (files: `index.html`)
- Inserted a compact inline portfolio access block between the hero and soluciones so Portfolio becomes a clear primary exploration path, and added `aria-label` attributes to important links. (files: `index.html`, `css/linear.css`)
- Centralized portfolio/home view logic and routing in `js/script.js` by adding shared functions `showHome`, `showPortfolio`, `scrollToTarget`, and `closeMobileMenu`, wired all portfolio triggers (navbar, hero CTA, inline CTA) to this single handler, and implemented robust hash handling (`#portfolio` on load/hashchange, normalized home hash). (files: `js/script.js`)
- CSS improvements to preserve the premium dark style while adding subtle hover/focus states and visible focus outlines, tightening hero spacing and button stacking for mobile, and styling the proof strip and quick-access block with minimal, muted visuals. (files: `css/linear.css`)
- Removed duplicated inline home/portfolio toggle code from `index.html` to avoid conflicting listeners and ensured no dead anchors or duplicated event listeners for portfolio toggles. (files: `index.html`, `js/script.js`)

### Testing
- JavaScript syntax smoke test passed by executing the updated `js/script.js` in Node to ensure no syntax errors. (result: success)
- Automated grep-based checks confirmed portfolio triggers now use the shared `data-portfolio-trigger` or `#open-portfolio-link` handler and that `#portfolio` hash is handled by the centralized router. (result: success)
- Visual/behavioral integrations left intact: AOS initialization, Calendly widget, contact form, and carousel scripts were not replaced by the changes (no automated visual regression available in this environment). (result: not applicable for automated visual tests)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d27001c2f0832292d7fa9ba5ea959e)