### PR TITLE
Enviar formulario de contacto por AJAX y evitar redirección a Formspree

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -175,6 +175,69 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     });
 
+    // Contact form submit without redirect (Formspree AJAX)
+    const contactForm = document.getElementById('contactForm');
+    const contactSubmitBtn = document.getElementById('contactSubmitBtn');
+    const contactSuccess = document.getElementById('contactSuccess');
+    const contactError = document.getElementById('contactError');
+
+    if (contactForm) {
+        contactForm.addEventListener('submit', async function (event) {
+            event.preventDefault();
+
+            contactSuccess?.classList.remove('is-visible');
+            contactError?.classList.remove('is-visible');
+            contactSubmitBtn?.classList.add('is-loading');
+            if (contactSubmitBtn) {
+                contactSubmitBtn.disabled = true;
+            }
+
+            const formData = new FormData(contactForm);
+            const endpoint = contactForm.getAttribute('action');
+
+            try {
+                const response = await fetch(endpoint, {
+                    method: 'POST',
+                    headers: {
+                        'Accept': 'application/json'
+                    },
+                    body: formData
+                });
+
+                if (!response.ok) {
+                    throw new Error('Form submission failed');
+                }
+
+                contactForm.reset();
+                contactSuccess?.classList.add('is-visible');
+
+                if (typeof gtag === 'function') {
+                    gtag('event', 'form_submit_success', {
+                        event_category: 'form',
+                        event_label: 'contact_form',
+                        section: 'contact_form'
+                    });
+                }
+            } catch (error) {
+                console.error('Contact form submit error:', error);
+                contactError?.classList.add('is-visible');
+
+                if (typeof gtag === 'function') {
+                    gtag('event', 'form_submit_error', {
+                        event_category: 'form',
+                        event_label: 'contact_form',
+                        section: 'contact_form'
+                    });
+                }
+            } finally {
+                contactSubmitBtn?.classList.remove('is-loading');
+                if (contactSubmitBtn) {
+                    contactSubmitBtn.disabled = false;
+                }
+            }
+        });
+    }
+
     // Cookie Consent Banner Logic
     const cookieBanner = document.getElementById('cookie-banner');
     const acceptCookiesBtn = document.getElementById('accept-cookies');


### PR DESCRIPTION
### Motivation
- Evitar que el envío del formulario de contacto redirija a la página de Formspree y mantener al usuario en la misma página. 
- Mostrar feedback inline (éxito/error) tras el envío para mejorar la experiencia de usuario. 
- Evitar envíos dobles y permitir instrumentar resultados con analytics.

### Description
- Intercepté el `submit` de `#contactForm` y llamo a Formspree mediante `fetch` para enviar `FormData` sin navegador redirect. 
- Uso de `event.preventDefault()` para detener la navegación y manejo de estados `is-loading` y `disabled` en el botón de envío. 
- Reaprovecho los elementos existentes `#contactSuccess` y `#contactError` y les aplico la clase `is-visible` para mostrar feedback inline. 
- Registro eventos de analytics (`form_submit_success` / `form_submit_error`) y manejo de errores con consola y UI.

### Testing
- Ejecutado `node --check js/script.js` y pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3f1c89cd08322b422e8424bf30741)